### PR TITLE
Feature: 의상 속성 정의 등록

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/common/exception/BaseException.java
+++ b/src/main/java/com/part4/team09/otboo/module/common/exception/BaseException.java
@@ -28,8 +28,7 @@ public class BaseException extends RuntimeException {
     this.details = details;
   }
 
-  public BaseException addDetail(String key, Object value) {
+  public void addDetail(String key, Object value) {
     this.details.put(key, value);
-    return this;
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/common/exception/BaseException.java
+++ b/src/main/java/com/part4/team09/otboo/module/common/exception/BaseException.java
@@ -27,4 +27,9 @@ public class BaseException extends RuntimeException {
     this.errorCode = errorCode;
     this.details = details;
   }
+
+  public BaseException addDetail(String key, Object value) {
+    this.details.put(key, value);
+    return this;
+  }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/controller/ClothesAttributeDefController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/controller/ClothesAttributeDefController.java
@@ -1,7 +1,15 @@
 package com.part4.team09.otboo.module.domain.clothes.controller;
 
+import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDefDto;
+import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefCreateRequest;
+import com.part4.team09.otboo.module.domain.clothes.service.ClothesAttributeInfoService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/clothes/attribute-defs")
 public class ClothesAttributeDefController {
 
+  // 의상 속성 정의 서비스
+  private final ClothesAttributeInfoService clothesAttributeInfoService;
+
+  // 의상 속성 정의 등록
+  @PostMapping
+  ResponseEntity<ClothesAttributeDefDto> create(@Valid @RequestBody ClothesAttributeDefCreateRequest request) {
+
+    ClothesAttributeDefDto response = clothesAttributeInfoService.create(request);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/data/ClothesAttributeDefDto.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/data/ClothesAttributeDefDto.java
@@ -1,0 +1,18 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.data;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ClothesAttributeDefDto(
+
+    // 속성 정의 id
+    UUID id,
+
+    // 속성 정의 이름
+    String name,
+
+    // 선택 가능한 값 목록
+    List<String> selectableValues
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/data/ClothesAttributeDto.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/data/ClothesAttributeDto.java
@@ -1,0 +1,14 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.data;
+
+import java.util.UUID;
+
+public record ClothesAttributeDto(
+
+    // 속성 정의 id
+    UUID definitionId,
+
+    // 선택한 속성 값
+    String value
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/data/ClothesAttributeWithDefDto.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/data/ClothesAttributeWithDefDto.java
@@ -1,0 +1,21 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.data;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ClothesAttributeWithDefDto(
+
+    // 속성 정의 id
+    UUID definitionId,
+
+    // 속성 정의 이름
+    String definitionName,
+
+    // 선택 가능한 값 목록
+    List<String> selectableValues,
+
+    // 선택한 속성 값
+    String value
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/data/ClothesDto.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/data/ClothesDto.java
@@ -1,0 +1,28 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.data;
+
+import com.part4.team09.otboo.module.domain.clothes.entity.Clothes.ClothesType;
+import java.util.List;
+import java.util.UUID;
+
+public record ClothesDto(
+
+    // 의상 id
+    UUID id,
+
+    // 소유자 id
+    UUID ownerId,
+
+    // 의상 이름
+    String name,
+
+    // 의상 이미지 URL
+    String imageUrl,
+
+    // 의상 타입
+    ClothesType type,
+
+    // 의상 속성
+    List<ClothesAttributeWithDefDto> attributes
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesAttributeDefCreateRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesAttributeDefCreateRequest.java
@@ -1,0 +1,23 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record ClothesAttributeDefCreateRequest(
+
+    // 속성 정의 이름
+    @NotBlank(message = "속성 정의 이름은 필수입니다.")
+    @Size(max = 50, message = "속성 정의 이름은 50자 이하여야 합니다.")
+    String name,
+
+    // 선택 가능한 값 목록
+    @NotEmpty(message = "선택 가능한 값은 1개 이상 있어야 합니다.")
+    @Valid
+    List<@NotBlank(message = "값 이름은 필수입니다.")
+         @Size(max = 50, message = "값 이름은 50자 이하여야 합니다.")
+         String> selectableValues
+) {
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesAttributeDefUpdateRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesAttributeDefUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record ClothesAttributeDefUpdateRequest(
+
+    // 속성 정의 이름
+    @NotBlank(message = "속성 정의 이름은 필수입니다.")
+    @Size(max = 50, message = "속성 정의 이름은 50자 이하여야 합니다.")
+    String name,
+
+    // 선택 가능한 값 목록
+    @NotEmpty(message = "선택 가능한 값은 1개 이상 있어야 합니다.")
+    @Valid
+    List<@NotBlank(message = "값 이름은 필수입니다.")
+    @Size(max = 50, message = "값 이름은 50자 이하여야 합니다.")
+        String> selectableValues
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesCreateRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesCreateRequest.java
@@ -1,0 +1,34 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.request;
+
+import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDto;
+import com.part4.team09.otboo.module.domain.clothes.entity.Clothes.ClothesType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.UUID;
+
+public record ClothesCreateRequest(
+
+    // 소유자 id
+    @NotNull(message = "소유자 ID는 필수입니다.")
+    UUID ownerId,
+
+    // 의상 이름
+    @NotBlank(message = "의상 이름은 필수입니다.")
+    @Size(max = 50, message = "의상 이름은 50자 이하여야 합니다.")
+    String name,
+
+    // 의상 타입
+    @NotNull(message = "의상 타입은 필수입니다.")
+    ClothesType type,
+
+    // 의상 속성
+    @Valid
+    @NotNull(message = "속성 리스트는 null일 수 없습니다.")
+    List<@Valid ClothesAttributeDto> attributes
+
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesUpdateRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.request;
+
+import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDto;
+import com.part4.team09.otboo.module.domain.clothes.entity.Clothes.ClothesType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record ClothesUpdateRequest(
+
+    // 의상 이름
+    @NotBlank(message = "의상 이름은 필수입니다.")
+    @Size(max = 50, message = "의상 이름은 50자 이하여야 합니다.")
+    String name,
+
+    // 의상 타입
+    @NotNull(message = "의상 타입은 필수입니다.")
+    ClothesType type,
+
+    // 의상 속성
+    @Valid
+    @NotNull(message = "속성 리스트는 null일 수 없습니다.")
+    List<ClothesAttributeDto> attributes
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/ClothesAttributeDef/ClothesAttributeDefAlreadyExistsException.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/ClothesAttributeDef/ClothesAttributeDefAlreadyExistsException.java
@@ -1,0 +1,17 @@
+package com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef;
+
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesErrorCode;
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesException;
+
+public class ClothesAttributeDefAlreadyExistsException extends ClothesException {
+
+  public ClothesAttributeDefAlreadyExistsException() {
+    super(ClothesErrorCode.DUPLICATE_ATTRIBUTE_DEF_NAME);
+  }
+
+  public static ClothesAttributeDefAlreadyExistsException withName(String name) {
+    ClothesAttributeDefAlreadyExistsException exception = new ClothesAttributeDefAlreadyExistsException();
+    exception.addDetail("name", name);
+    return exception;
+  }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/ClothesAttributeDef/ClothesAttributeDefNotFoundException.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/ClothesAttributeDef/ClothesAttributeDefNotFoundException.java
@@ -1,0 +1,18 @@
+package com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef;
+
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesErrorCode;
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesException;
+import java.util.UUID;
+
+public class ClothesAttributeDefNotFoundException extends ClothesException {
+
+  public ClothesAttributeDefNotFoundException() {
+    super(ClothesErrorCode.ATTRIBUTE_DEF_NOT_FOUND);
+  }
+
+  public static ClothesAttributeDefNotFoundException withId(UUID id) {
+    ClothesAttributeDefNotFoundException exception = new ClothesAttributeDefNotFoundException();
+    exception.addDetail("id", id);
+    return exception;
+  }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/ClothesErrorCode.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/ClothesErrorCode.java
@@ -1,0 +1,29 @@
+package com.part4.team09.otboo.module.domain.clothes.exception;
+
+import com.part4.team09.otboo.module.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ClothesErrorCode implements ErrorCode {
+
+  // ClothesAttributeDef 에러 코드
+  DUPLICATE_ATTRIBUTE_DEF_NAME(HttpStatus.CONFLICT, "중복된 의상 속성 정의 명입니다."),
+  ATTRIBUTE_DEF_NOT_FOUND(HttpStatus.NOT_FOUND, "의상 속성 정의를 찾을 수 없습니다.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  ClothesErrorCode(HttpStatus status, String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() {
+    return this.status;
+  }
+
+  @Override
+  public String getMessage() {
+    return this.message;
+  }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/ClothesException.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/ClothesException.java
@@ -1,0 +1,20 @@
+package com.part4.team09.otboo.module.domain.clothes.exception;
+
+import com.part4.team09.otboo.module.common.exception.BaseException;
+import com.part4.team09.otboo.module.common.exception.ErrorCode;
+import java.util.Map;
+
+public class ClothesException extends BaseException {
+
+  public ClothesException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public ClothesException(String message, ErrorCode errorCode) {
+    super(message, errorCode);
+  }
+
+  public ClothesException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesAttributeDefRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesAttributeDefRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClothesAttributeDefRepository extends JpaRepository<ClothesAttributeDef, UUID> {
 
+  boolean existsByName(String name);
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefService.java
@@ -1,10 +1,28 @@
 package com.part4.team09.otboo.module.domain.clothes.service;
 
+import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefAlreadyExistsException;
+import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ClothesAttributeDefService {
 
+  private final ClothesAttributeDefRepository clothesAttributeDefRepository;
+
+  public ClothesAttributeDef create(String name) {
+
+    // 프로토타입에는 없지만 이름 중복 검사
+    if (clothesAttributeDefRepository.existsByName(name)) {
+      throw ClothesAttributeDefAlreadyExistsException.withName(name);
+    }
+
+    ClothesAttributeDef def = ClothesAttributeDef.create(name);
+
+    return clothesAttributeDefRepository.save(def);
+  }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoService.java
@@ -1,0 +1,35 @@
+package com.part4.team09.otboo.module.domain.clothes.service;
+
+
+
+
+import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDefDto;
+import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefCreateRequest;
+import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
+
+import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ClothesAttributeInfoService {
+
+  // 의상 속성 정의 관련 서비스
+  private final ClothesAttributeDefService clothesAttributeDefService;
+
+  // 의상 속성 값 관련 서비스
+  private final SelectableValueService selectableValueService;
+
+  public ClothesAttributeDefDto create(ClothesAttributeDefCreateRequest request) {
+
+    ClothesAttributeDef def = clothesAttributeDefService.create(request.name());
+
+    List<String> valueList = selectableValueService.create(def.getId(), request.selectableValues()).stream()
+        .map(SelectableValue::getItem)
+        .toList();
+
+    return new ClothesAttributeDefDto(def.getId(), def.getName(), valueList);
+  }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueService.java
@@ -1,10 +1,33 @@
 package com.part4.team09.otboo.module.domain.clothes.service;
 
+import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefNotFoundException;
+import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
+import com.part4.team09.otboo.module.domain.clothes.repository.SelectableValueRepository;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class SelectableValueService {
 
+  private final SelectableValueRepository selectableValueRepository;
+  private final ClothesAttributeDefRepository clothesAttributeDefRepository;
+
+  public List<SelectableValue> create(UUID defId, List<String> values) {
+
+    clothesAttributeDefRepository.findById(defId)
+        .orElseThrow(() -> ClothesAttributeDefNotFoundException.withId(defId));
+
+
+    List<SelectableValue> selectableValues = values.stream()
+        .map(value -> SelectableValue.create(defId, value))
+        .toList();
+
+    return selectableValueRepository.saveAll(selectableValues);
+  }
 }

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefServiceTest.java
@@ -1,0 +1,66 @@
+package com.part4.team09.otboo.module.domain.clothes.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefAlreadyExistsException;
+import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClothesAttributeDefServiceTest {
+
+  @InjectMocks
+  private ClothesAttributeDefService clothesAttributeDefService;
+
+  @Mock
+  private ClothesAttributeDefRepository clothesAttributeDefRepository;
+
+  @Nested
+  @DisplayName("의상 속성 정의 생성")
+  class CreateTest {
+
+    @Test
+    @DisplayName("생성 성공")
+    void create_success() {
+
+      // given
+      String name = "사이즈";
+      ClothesAttributeDef def = ClothesAttributeDef.create(name);
+
+      given(clothesAttributeDefRepository.existsByName(name)).willReturn(false);
+      given(clothesAttributeDefRepository.save(any(ClothesAttributeDef.class))).willReturn(def);
+
+      // when
+      ClothesAttributeDef result = clothesAttributeDefService.create(name);
+
+      // then
+      assertNotNull(result);
+      assertEquals(result.getName(), def.getName());
+      then(clothesAttributeDefRepository).should().existsByName(name);
+      then(clothesAttributeDefRepository).should().save(any(ClothesAttributeDef.class));
+    }
+
+    @Test
+    @DisplayName("이름 중복")
+    void create_duplicate_name() {
+
+      // given
+      String name = "사이즈";
+
+      given(clothesAttributeDefRepository.existsByName(name)).willReturn(true);
+
+      // when, then
+      assertThrows(ClothesAttributeDefAlreadyExistsException.class, () -> clothesAttributeDefService.create(name));
+    }
+  }
+}

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoServiceTest.java
@@ -1,0 +1,62 @@
+package com.part4.team09.otboo.module.domain.clothes.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDefDto;
+import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefCreateRequest;
+import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
+import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClothesAttributeInfoServiceTest {
+
+  @InjectMocks
+  private ClothesAttributeInfoService clothesAttributeInfoService;
+
+  @Mock
+  private ClothesAttributeDefService clothesAttributeDefService;
+
+  @Mock
+  private SelectableValueService selectableValueService;
+
+  @Nested
+  @DisplayName("의상 속성 생성")
+  class Create {
+
+    @Test
+    @DisplayName("생성 성공")
+    void create_success() {
+
+      // given
+      ClothesAttributeDefCreateRequest request = new ClothesAttributeDefCreateRequest("사이즈", List.of("S", "M", "L"));
+
+      ClothesAttributeDef def = ClothesAttributeDef.create(request.name());
+      List<SelectableValue> selectableValues = request.selectableValues().stream()
+          .map(value -> SelectableValue.create(def.getId(), value))
+          .toList();
+
+      given(clothesAttributeDefService.create(request.name())).willReturn(def);
+      given(selectableValueService.create(def.getId(), request.selectableValues())).willReturn(selectableValues);
+
+      // when
+      ClothesAttributeDefDto result = clothesAttributeInfoService.create(request);
+
+      // then
+      assertNotNull(result);
+      assertEquals(result.name(), request.name());
+      assertEquals(result.selectableValues(), request.selectableValues());
+      then(clothesAttributeDefService).should().create(request.name());
+      then(selectableValueService).should().create(def.getId(), request.selectableValues());
+    }
+  }
+}

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueServiceTest.java
@@ -1,0 +1,80 @@
+package com.part4.team09.otboo.module.domain.clothes.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
+import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefNotFoundException;
+import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
+import com.part4.team09.otboo.module.domain.clothes.repository.SelectableValueRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SelectableValueServiceTest {
+
+  @InjectMocks
+  private SelectableValueService selectableValueService;
+
+  @Mock
+  private SelectableValueRepository selectableValueRepository;
+
+  @Mock
+  private ClothesAttributeDefRepository clothesAttributeDefRepository;
+
+  @Nested
+  @DisplayName("속성 값 생성")
+  class Create {
+
+    @Test
+    @DisplayName("생성 성공")
+    void create_success() {
+
+      // given
+      UUID defId = UUID.randomUUID();
+      List<String> values = List.of("S", "M", "L", "XL");
+
+      ClothesAttributeDef def = ClothesAttributeDef.create("사이즈");
+      List<SelectableValue> selectableValues = values.stream()
+          .map(value -> SelectableValue.create(defId, value))
+          .toList();
+
+      given(clothesAttributeDefRepository.findById(defId)).willReturn(Optional.of(def));
+      given(selectableValueRepository.saveAll(anyList())).willReturn(selectableValues);
+
+      // when
+      List<SelectableValue> result = selectableValueService.create(defId, values);
+
+      // then
+      assertNotNull(result);
+      assertEquals(result.get(0), selectableValues.get(0));
+      then(clothesAttributeDefRepository).should().findById(defId);
+      then(selectableValueRepository).should().saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("속성 정의 id 중복")
+    void create_duplicate_def_id() {
+
+      // given
+      UUID defId = UUID.randomUUID();
+      List<String> values = List.of("S", "M", "L", "XL");
+
+      given(clothesAttributeDefRepository.findById(defId)).willReturn(Optional.empty());
+
+      // when, then
+      assertThrows(ClothesAttributeDefNotFoundException.class, () -> selectableValueService.create(defId, values));
+    }
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,7 +6,7 @@ spring:
     password:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -10,7 +10,12 @@ spring:
     show-sql: true
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
         format_sql: true
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: never
 
 logging:
   level:


### PR DESCRIPTION
## Issue Number
19


## 요약(Summary)
- 의상 속성 정의 등록과 관련된 controller, service, repository, exception을 구현했습니다.


## PR 유형

어떤 변경 사항이 있나요?
### dto 관련
- 의상 관련 dto를 구현했습니다. (스웨거 문서와 동일)
- 프로토타입에는 속성 정의가 null이여도 생성되지만 not blank를 사용해 null, "", " "을 막았습니다.
- 속성 값은 적어도 1개의 속성 값이 있어야 생성되도록 구현했습니다.

### 컨트롤러 (ClothesAttributeDefController)
- 의상 속성 정의 등록 관련 코드를 구현했습니다.

### 서비스 
#### 의상 속성 로직 클래스 (ClothesAttributeInfoService)
- ClothesAttributeInfoService를 통해 속성 정의 서비스(ex. 사이즈)와 속성 값 서비스(ex. S, M)을 묶었습니다.
- (정의, 속성값)을 처리하는 클래스입니다.

#### 의상 속성 정의 서비스 (ClothesAttributeDefService)
- 이미 이름이 존재하면 예외처리를 했습니다(ex. 사이즈라는 이름과 같은 정의가 존재하면 예외처리)

#### 의상 속성 값 서비스 (SelectableValueService)
- 정의 id가 없으면 예외가 발생하도록 구현했습니다.
- 단순히 정의 id 검사에만 사용하기 때문에 의상 정의 리포지토리를 의존했습니다. 

### 테스트
#### 서비스 테스트
- 위 3개의 서비스에 대한 테스트를 작성했습니다.
- 리포지토리 테스트는 스키마가 수정된 내일 작성할 예정입니다.

#### postman
- 201, 400, 409. 구현한 예외처리에 대해서도 테스트 했습니다. 

### 나머지
- 의상 정의 관련 에러 코드를 작성했습니다.
- BaseException에 addDetail을 추가했습니다.
- application-test.yml을 수정했습니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)
![postman_201](https://github.com/user-attachments/assets/ca730dcd-ebce-4ce3-b9de-12625293dcd8)
![postman_400_name](https://github.com/user-attachments/assets/f85bb8a1-9fb1-422b-b42c-eef72665ebf3)
![postman_400_values](https://github.com/user-attachments/assets/3c1cc85a-86d2-4963-93bc-44af54960044)
![postman_409](https://github.com/user-attachments/assets/164b1795-eece-4a2b-8855-3886a6008525)


close https://github.com/SB01-Team09/sb01-otboo-team09/issues/19
## 공유사항 to 리뷰어



