### PR TITLE
Feature: 의상 속성 정의 update 로직 추가

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesAttributeRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesAttributeRepository.java
@@ -1,10 +1,12 @@
 package com.part4.team09.otboo.module.domain.clothes.repository;
 
 import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttribute;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface ClothesAttributeRepository extends JpaRepository<ClothesAttribute, UUID> {
 
+  void deleteBySelectableValueIdIn(List<UUID> oldValueIds);
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepository.java
@@ -1,11 +1,16 @@
 package com.part4.team09.otboo.module.domain.clothes.repository;
 
 import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface SelectableValueRepository extends JpaRepository<SelectableValue, UUID> {
 
+  List<SelectableValue> findAllByAttributeDefId(UUID defId);
+
   void deleteAllByAttributeDefId(UUID attributeDefId);
+
+  void deleteByIdIn(List<UUID> valueIdsForDelete);
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefService.java
@@ -53,4 +53,15 @@ public class ClothesAttributeDefService {
     log.debug("의상 속성 정의 명 수정 완료: defId = {}, name = {}", def.getId(), def.getName());
     return def;
   }
+
+  // 의상 속성 정의 명 찾기
+  public ClothesAttributeDef findById(UUID defId) {
+    log.debug("의상 속성 정의 명 찾기 시작: defId = {}", defId);
+
+    return clothesAttributeDefRepository.findById(defId)
+        .orElseThrow(() -> {
+          log.warn("의상 속성 정의가 존재하지 않습니다. id = {}", defId);
+          return ClothesAttributeDefNotFoundException.withId(defId);
+        });
+  }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeService.java
@@ -1,0 +1,25 @@
+package com.part4.team09.otboo.module.domain.clothes.service;
+
+import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
+import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ClothesAttributeService {
+
+  private final ClothesAttributeRepository clothesAttributeRepository;
+
+  public void deleteBySelectableValueIdIn(List<UUID> oldValueIds) {
+
+    // 로직이 더 추가되면 테스트 작성하겠습니다.
+    clothesAttributeRepository.deleteBySelectableValueIdIn(oldValueIds);
+  }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueService.java
@@ -4,7 +4,13 @@ import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefNotFoundException;
 import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
 import com.part4.team09.otboo.module.domain.clothes.repository.SelectableValueRepository;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,9 +46,39 @@ public class SelectableValueService {
     return selectableValueRepository.saveAll(selectableValues);
   }
 
-  public List<SelectableValue> update(UUID defId, List<String> newValues) {
+  public List<SelectableValue> updateWhenNameSame(UUID defId, List<UUID> valueIdsForDelete,
+      List<String> newValues) {
 
-    log.debug("의상 속성 명 수정 시작: defId = {}, newValues = {}", defId, newValues);
+    log.debug("의상 속성 명 수정(정의 명 수정 X) 시작: defId = {}, newValues = {}", defId, newValues);
+
+    // id 검사
+    validateDefId(defId);
+
+    // 삭제할 속성 삭제
+    selectableValueRepository.deleteByIdIn(valueIdsForDelete);
+
+    List<String> oldValues = selectableValueRepository.findAllByAttributeDefId(defId).stream()
+        .map(SelectableValue::getItem)
+        .toList();
+    Set<String> oldValueSet = new HashSet<>(oldValues);
+
+    // 속성 값 생성
+    List<SelectableValue> selectableValues = newValues.stream()
+        .filter(value -> !oldValueSet.contains(value))
+        .map(value -> SelectableValue.create(defId, value))
+        .toList();
+
+    log.debug("의상 속성 명 수정(정의 명 수정 X) 완료: defId = {}, values = {}", defId,
+        selectableValues.stream()
+            .map(SelectableValue::getItem)
+            .toList());
+    selectableValueRepository.saveAll(selectableValues);
+    return selectableValueRepository.findAllByAttributeDefId(defId);
+  }
+
+  public List<SelectableValue> updateWhenNameChanged(UUID defId, List<String> newValues) {
+
+    log.debug("의상 속성 명 수정(정의 명 수정 O) 시작: defId = {}, newValues = {}", defId, newValues);
 
     // id 검사
     validateDefId(defId);
@@ -52,13 +88,20 @@ public class SelectableValueService {
 
     // 속성 값 생성
     List<SelectableValue> selectableValues = newValues.stream()
-        .map(value -> SelectableValue.create(defId, value)).toList();
+        .map(value -> SelectableValue.create(defId, value))
+        .toList();
 
-    log.debug("의상 속성 명 수정 완료: defId = {}, values = {}", defId,
+    log.debug("의상 속성 명 수정(정의 명 수정 O)  완료: defId = {}, values = {}", defId,
         selectableValues.stream()
             .map(SelectableValue::getItem)
             .toList());
     return selectableValueRepository.saveAll(selectableValues);
+  }
+
+  // 속성 정의 명에 해당되는 속성 값들 반환
+  public List<SelectableValue> findAllByAttributeDefId(UUID defId) {
+
+    return selectableValueRepository.findAllByAttributeDefId(defId);
   }
 
   // defId 유효성 검사

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesAttributeRepositoryTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesAttributeRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.part4.team09.otboo.module.domain.clothes.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttribute;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@EnableJpaAuditing
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackageClasses = ClothesAttributeRepository.class)
+class ClothesAttributeRepositoryTest {
+
+  @Autowired
+  private ClothesAttributeRepository clothesAttributeRepository;
+
+  @Autowired
+  private EntityManager entityManager;
+
+  @Nested
+  @DisplayName("속성 값 id로 삭제")
+  class DeleteBySelectableValueIdIn {
+
+    @Test
+    @DisplayName("삭제 성공")
+    void delete_by_selectable_value_id_in() {
+
+      // given
+      UUID clothesId = UUID.randomUUID();
+      UUID selectableValueId = UUID.randomUUID();
+
+      ClothesAttribute clothesAttribute = ClothesAttribute.create(clothesId, selectableValueId);
+
+      clothesAttributeRepository.save(clothesAttribute);
+      entityManager.flush();
+      entityManager.clear();
+
+      // when
+      clothesAttributeRepository.deleteBySelectableValueIdIn(List.of(selectableValueId));
+      List<ClothesAttribute> result = clothesAttributeRepository.findAll();
+
+      // then
+      assertTrue(result.isEmpty());
+    }
+  }
+}

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepositoryTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepositoryTest.java
@@ -1,10 +1,14 @@
 package com.part4.team09.otboo.module.domain.clothes.repository;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,6 +29,34 @@ class SelectableValueRepositoryTest {
 
   @Autowired
   private EntityManager entityManager;
+
+  @Nested
+  @DisplayName("속성 정의 id로 속성 값들 찾기")
+  class FindAllByAttributeDefId {
+
+    @Test
+    @DisplayName("찾기 성공")
+    void find_all_by_attribute_def_id() {
+      // given
+      UUID defId = UUID.randomUUID();
+      List<SelectableValue> selectableValues = Stream.of("S", "M", "L")
+          .map(value -> SelectableValue.create(defId, value))
+          .toList();
+
+      selectableValueRepository.saveAll(selectableValues);
+      entityManager.flush();
+      entityManager.clear();
+
+      // given
+      List<SelectableValue> results = selectableValueRepository.findAllByAttributeDefId(defId);
+
+      // then
+      assertEquals(
+          results.stream().map(SelectableValue::getItem).toList(),
+          selectableValues.stream().map(SelectableValue::getItem).toList()
+      );
+    }
+  }
 
   @Nested
   @DisplayName("의상 속성 정의 id로 속성 값 전부 삭제")
@@ -51,7 +83,7 @@ class SelectableValueRepositoryTest {
       List<SelectableValue> result = selectableValueRepository.findAll();
 
       // then
-      assertEquals(result, List.of());
+      assertTrue(result.isEmpty());
     }
 
     @Test
@@ -63,6 +95,31 @@ class SelectableValueRepositoryTest {
 
       // when, then
       assertDoesNotThrow(() -> selectableValueRepository.deleteAllByAttributeDefId(invalidId));
+    }
+  }
+
+  @Nested
+  @DisplayName("아이디 리스트로 삭제")
+  class DeleteByIdIn {
+
+    @Test
+    @DisplayName("리스트로 삭제 성공")
+    void delete_by_id_in() {
+
+      // given
+      UUID id = UUID.randomUUID();
+      SelectableValue selectableValue = SelectableValue.create(id, "S");
+
+      selectableValueRepository.save(selectableValue);
+      entityManager.flush();
+      entityManager.clear();
+
+      // when
+      selectableValueRepository.deleteByIdIn(List.of(selectableValue.getId()));
+      List<SelectableValue> result = selectableValueRepository.findAll();
+
+      // then
+      assertTrue(result.isEmpty());
     }
   }
 }

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefServiceTest.java
@@ -66,7 +66,7 @@ class ClothesAttributeDefServiceTest {
 
       // when, then
       assertThrows(ClothesAttributeDefAlreadyExistsException.class,
-        () -> clothesAttributeDefService.create(name));
+          () -> clothesAttributeDefService.create(name));
     }
   }
 
@@ -104,7 +104,45 @@ class ClothesAttributeDefServiceTest {
       given(clothesAttributeDefRepository.findById(defId)).willReturn(Optional.empty());
 
       // when, then
-      assertThrows(ClothesAttributeDefNotFoundException.class, () -> clothesAttributeDefService.update(defId, "신축성"));
+      assertThrows(ClothesAttributeDefNotFoundException.class,
+          () -> clothesAttributeDefService.update(defId, "신축성"));
+    }
+  }
+
+  @Nested
+  @DisplayName("의상 속성 정의 찾기")
+  class FindById {
+
+    @Test
+    @DisplayName("찾기 성공")
+    void find_by_id_success() {
+
+      // given
+      UUID id = UUID.randomUUID();
+      ClothesAttributeDef def = ClothesAttributeDef.create("사이즈");
+
+      given(clothesAttributeDefRepository.findById(id)).willReturn(Optional.of(def));
+
+      // when
+      ClothesAttributeDef result = clothesAttributeDefService.findById(id);
+
+      // then
+      assertNotNull(result);
+      assertEquals(def, result);
+      then(clothesAttributeDefRepository).should().findById(id);
+    }
+
+    @Test
+    @DisplayName("찾기 실패 - 잘못된 id")
+    void find_by_id_not_found_id() {
+
+      // given
+      UUID id = UUID.randomUUID();
+
+      given(clothesAttributeDefRepository.findById(id)).willReturn(Optional.empty());
+
+      // when, then
+      assertThrows(ClothesAttributeDefNotFoundException.class, () -> clothesAttributeDefService.findById(id));
     }
   }
 }

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueServiceTest.java
@@ -6,13 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefNotFoundException;
 import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
 import com.part4.team09.otboo.module.domain.clothes.repository.SelectableValueRepository;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -46,8 +50,7 @@ class SelectableValueServiceTest {
       List<String> values = List.of("S", "M", "L", "XL");
 
       List<SelectableValue> selectableValues = values.stream()
-        .map(value -> SelectableValue.create(defId, value))
-        .toList();
+          .map(value -> SelectableValue.create(defId, value)).toList();
 
       given(clothesAttributeDefRepository.existsById(defId)).willReturn(true);
       given(selectableValueRepository.saveAll(anyList())).willReturn(selectableValues);
@@ -82,12 +85,62 @@ class SelectableValueServiceTest {
   class Update {
 
     @Test
-    @DisplayName("수정 성공")
-    void update_success() {
+    @DisplayName("정의 명 수정 X - 성공")
+    void update_when_name_same_success() {
+      // given
+      UUID defId = UUID.randomUUID();
+      List<UUID> valueIdsForDelete = List.of(UUID.randomUUID(), UUID.randomUUID());
+      List<String> newValues = List.of("M", "L", "XL");
+      List<String> oldValues = List.of("S", "M", "L");
+      List<SelectableValue> oldSelectableValues = oldValues.stream()
+          .map(value -> SelectableValue.create(defId, value))
+          .toList();
+      Set<String> oldValueSet = new HashSet<>(oldValues);
+      List<SelectableValue> selectableValues = newValues.stream()
+          .filter(value -> !oldValueSet.contains(value))
+          .map(value -> SelectableValue.create(defId, value))
+          .toList();
+      List<SelectableValue> findSelectableValues = newValues.stream()
+          .map(value -> SelectableValue.create(defId, value))
+          .toList();
+
+      given(clothesAttributeDefRepository.existsById(defId)).willReturn(true);
+      given(selectableValueRepository.findAllByAttributeDefId(defId)).willReturn(oldSelectableValues);
+      given(selectableValueRepository.saveAll(anyList())).willReturn(selectableValues);
+      given(selectableValueRepository.findAllByAttributeDefId(defId)).willReturn(findSelectableValues);
+
+      // when
+      List<SelectableValue> results = selectableValueService.updateWhenNameSame(defId, valueIdsForDelete, newValues);
+
+      // then
+      assertNotNull(results);
+      assertEquals(results, findSelectableValues);
+      then(clothesAttributeDefRepository).should().existsById(defId);
+      then(selectableValueRepository).should().deleteByIdIn(valueIdsForDelete);
+      then(selectableValueRepository).should(times(2)).findAllByAttributeDefId(defId);
+      then(selectableValueRepository).should().saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("정의 명 수정 X - 잘못된 def id")
+    void update_when_name_same_not_found_def() {
+      //given
+      UUID defId = UUID.randomUUID();
+
+      given(clothesAttributeDefRepository.existsById(defId)).willReturn(false);
+
+      // when, then
+      assertThrows(ClothesAttributeDefNotFoundException.class,
+          () -> selectableValueService.updateWhenNameSame(defId, List.of(), List.of()));
+    }
+
+    @Test
+    @DisplayName("정의 명 수정 O - 성공")
+    void update_when_name_changed_success() {
 
       // given
       UUID defId = UUID.randomUUID();
-      List<String> newValues = List.of("없음", "조금 있음", "있음");
+      List<String> newValues = List.of("M", "L", "XL");
       List<SelectableValue> selectableValues = newValues.stream()
           .map(value -> SelectableValue.create(defId, value))
           .toList();
@@ -96,27 +149,53 @@ class SelectableValueServiceTest {
       given(selectableValueRepository.saveAll(anyList())).willReturn(selectableValues);
 
       // when
-      List<SelectableValue> result = selectableValueService.update(defId, newValues);
+      List<SelectableValue> results = selectableValueService.updateWhenNameChanged(defId, newValues);
 
       // then
-      assertNotNull(result);
-      assertEquals(result, selectableValues);
+      assertNotNull(results);
+      assertEquals(results, selectableValues);
       then(clothesAttributeDefRepository).should().existsById(defId);
+      then(selectableValueRepository).should().deleteAllByAttributeDefId(defId);
       then(selectableValueRepository).should().saveAll(anyList());
     }
 
     @Test
-    @DisplayName("잘못된 속성 정의 id")
-    void update_invalid_id() {
-
-      // given
+    @DisplayName("정의 명 수정 X - 잘못된 def id")
+    void update_when_name_changed_not_found_def() {
+      //given
       UUID defId = UUID.randomUUID();
 
       given(clothesAttributeDefRepository.existsById(defId)).willReturn(false);
 
       // when, then
       assertThrows(ClothesAttributeDefNotFoundException.class,
-          () -> selectableValueService.update(defId, List.of()));
+          () -> selectableValueService.updateWhenNameChanged(defId, List.of()));
+    }
+  }
+
+  @Nested
+  @DisplayName("속성 값 def id로 찾기")
+  class findAllByAttributeDefId {
+
+    @Test
+    @DisplayName("속성 값 def id로 찾기 성공")
+    void find_all_by_attribute_def_id_success() {
+
+      // given
+      UUID defId = UUID.randomUUID();
+      List<SelectableValue> selectableValues = Stream.of("S", "M", "L")
+          .map(value -> SelectableValue.create(defId, value))
+          .toList();
+
+      given(selectableValueRepository.findAllByAttributeDefId(defId)).willReturn(selectableValues);
+
+      // when
+      List<SelectableValue> results = selectableValueService.findAllByAttributeDefId(defId);
+
+      // then
+      assertNotNull(results);
+      assertEquals(results, selectableValues);
+      then(selectableValueRepository).should().findAllByAttributeDefId(defId);
     }
   }
 }


### PR DESCRIPTION
## Issue Number
32

## 요약(Summary)
- 의상 속성 정의 수정 부분 관련 로직을 추가했습니다.
- 
## PR 유형

어떤 변경 사항이 있나요?

- [] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)
[의상 속성 정의 수정 V2 - 로직 추가.postman_collection.json](https://github.com/user-attachments/files/20941451/V2.-.postman_collection.json)

## 공유사항 to 리뷰어

### 로직 추가
1. 속성 정의 명이 바뀌었을 경우
- 이전에 있던 속성 값들을 전부 삭제합니다
- 의상과 이전 속성 값을 담은 clothesAttribute 엔티티도 삭제합니다.
- 사용자가 선택하지 않은 속성 값이 선택되지 않도록 하기 위함입니다.
- ex) 신축성: 없음 -> 두께감: 없음 으로 정의 명이 변경 시 사용자가 선택한 정의 명이 달라져 삭제하도록 구현했습니다.
2. 속성 정의 명이 바뀌지 않았을 경우
- 수정 리퀘스트에 있는 속성 값은 남겨두고 리퀘스트에 없는 속성 값을 삭제합니다.
- 위와 같이 해당되는 clothesAttribute 엔티티도 삭제합니다.
- 그 후 새로 추가되는 속성 값을 생성합니다.
- ex) 사이즈: S, M, L -> 사이즈: M, L, XL 이라면 M, L은 삭제되지 않고 S와 S를 참조하는 clothesAttribute 엔티티가 삭제됩니다. XL 엔티티가 생성됩니다.

### 바뀐 부분
- 이전에는 수정할 때마다 엔티티가 삭제되었습니다. 정의 명이나 값에 따라 삭제가 이루어집니다.

### 테스트
- 바뀐 부분 테스트 완료했습니다.
## Close Issue

close #32