### PR TITLE
Feature: 팔로잉 목록 조회

### DIFF
--- a/src/main/java/com/part4/team09/otboo/config/QueryDslConfig.java
+++ b/src/main/java/com/part4/team09/otboo/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.part4.team09.otboo.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/contoller/FollowController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/contoller/FollowController.java
@@ -6,11 +6,10 @@ import com.part4.team09.otboo.module.domain.follow.service.FollowService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.http.HttpStatus;
+
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -32,6 +31,19 @@ public class FollowController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(followDto);
+    }
+
+    // TODO: 팔로잉 리스트 조회
+    @GetMapping("/api/follows/followings")
+    public ResponseEntity<FollowDto> getFollowingList(
+            @RequestParam UUID followerId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) UUID idAfter,
+            @RequestParam Integer limit,
+            @RequestParam(required = false) String nameLike
+            ){
+
+
     }
 
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/contoller/FollowController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/contoller/FollowController.java
@@ -2,6 +2,7 @@ package com.part4.team09.otboo.module.domain.follow.contoller;
 
 import com.part4.team09.otboo.module.domain.follow.dto.FollowCreateRequest;
 import com.part4.team09.otboo.module.domain.follow.dto.FollowDto;
+import com.part4.team09.otboo.module.domain.follow.dto.FollowListResponse;
 import com.part4.team09.otboo.module.domain.follow.service.FollowService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,28 +23,28 @@ public class FollowController {
     // 팔로우 요청
     @PostMapping
     public ResponseEntity<FollowDto> follow(@RequestBody FollowCreateRequest request){
-        log.info("팔로우 요청: followee={} -> follower={}", request.followeeId(), request.followerId());
 
         FollowDto followDto = followService.create(request.followeeId(), request.followerId());
-
-        log.info("팔로우 완료: followId={}", followDto.id());
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(followDto);
     }
 
-    // TODO: 팔로잉 리스트 조회
-    @GetMapping("/api/follows/followings")
-    public ResponseEntity<FollowDto> getFollowingList(
+    // 팔로잉 목록 조회
+    @GetMapping("/followings")
+    public ResponseEntity<FollowListResponse> getFollowings(
             @RequestParam UUID followerId,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) UUID idAfter,
-            @RequestParam Integer limit,
+            @RequestParam(defaultValue = "10") Integer limit,
             @RequestParam(required = false) String nameLike
             ){
 
+        FollowListResponse response = followService.getFollowings(followerId, idAfter, limit, nameLike);
 
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
     }
-
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/dto/FollowListResponse.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/dto/FollowListResponse.java
@@ -1,0 +1,20 @@
+package com.part4.team09.otboo.module.domain.follow.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record FollowListResponse(
+        List<FollowDto> data,
+        String nextCursor,
+        UUID nextIdAfter,
+        boolean hasNext,
+        Integer totalCount,
+        String sortBy,
+        SortDirection sortDirection
+
+) {
+    public enum SortDirection {
+        ASCENDING,
+        DESCENDING
+    }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/entity/Follow.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/entity/Follow.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.util.UUID;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/exception/FollowErrorCode.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/exception/FollowErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum FollowErrorCode implements ErrorCode {
 
-    SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다.");
+    SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
+    NEGATIVE_LIMIT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "limit은 0보다 커야합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/exception/NegativeLimitNotAllowed.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/exception/NegativeLimitNotAllowed.java
@@ -1,0 +1,11 @@
+package com.part4.team09.otboo.module.domain.follow.exception;
+
+import com.part4.team09.otboo.module.common.exception.BaseException;
+
+import java.util.Map;
+
+public class NegativeLimitNotAllowed extends BaseException {
+    public NegativeLimitNotAllowed(Integer limit) {
+        super(FollowErrorCode.NEGATIVE_LIMIT_NOT_ALLOWED, Map.of("limit", limit));
+    }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/repository/FollowRepository.java
@@ -1,17 +1,36 @@
 package com.part4.team09.otboo.module.domain.follow.repository;
 
 import com.part4.team09.otboo.module.domain.follow.entity.Follow;
-
 import java.util.List;
 import java.util.UUID;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 
 public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
-    // 팔로잉 목록 조회: 처음부터
-    List<Follow> findAllByFollowerIdOrderByIdAtDesc(UUID followerId, Pageable pageable);
+    // 검색어 X : JPQL
 
-    // 팔로잉 목록 조회: idAfter부터
-    List<Follow> findAllByFollowerIdAndIdLessThenOrderByIdAtDesc(UUID followerId, UUID idAfter, Pageable pageable);
+    // 전체 팔로잉 목록 조회: idAfter가 null이면 처음부터 반환, null이 아니면 커서페이징대로 진행
+    @Query("""
+    SELECT f FROM Follow f
+    WHERE f.followerId = :followerId
+      AND (:idAfter IS NULL OR f.id < :idAfter)
+    ORDER BY f.id DESC """)
+    List<Follow> getAllFollowings(
+            @Param("followerId") UUID followerId,
+            @Param("idAfter") UUID idAfter,
+            Pageable pageable
+    );
+
+    // 전체 팔로잉 목록 전체 개수 (totalCount)
+    @Query("""
+    SELECT COUNT(f) FROM Follow f
+    WHERE f.followerId = :followerId """)
+    int countAllFollowings(
+            @Param("followerId") UUID followerId
+    );
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/repository/FollowRepository.java
@@ -1,36 +1,11 @@
 package com.part4.team09.otboo.module.domain.follow.repository;
 
 import com.part4.team09.otboo.module.domain.follow.entity.Follow;
-import java.util.List;
 import java.util.UUID;
-
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 
 public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
-    // 검색어 X : JPQL
 
-    // 전체 팔로잉 목록 조회: idAfter가 null이면 처음부터 반환, null이 아니면 커서페이징대로 진행
-    @Query("""
-    SELECT f FROM Follow f
-    WHERE f.followerId = :followerId
-      AND (:idAfter IS NULL OR f.id < :idAfter)
-    ORDER BY f.id DESC """)
-    List<Follow> getAllFollowings(
-            @Param("followerId") UUID followerId,
-            @Param("idAfter") UUID idAfter,
-            Pageable pageable
-    );
-
-    // 전체 팔로잉 목록 전체 개수 (totalCount)
-    @Query("""
-    SELECT COUNT(f) FROM Follow f
-    WHERE f.followerId = :followerId """)
-    int countAllFollowings(
-            @Param("followerId") UUID followerId
-    );
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/repository/FollowRepository.java
@@ -1,9 +1,17 @@
 package com.part4.team09.otboo.module.domain.follow.repository;
 
 import com.part4.team09.otboo.module.domain.follow.entity.Follow;
+
+import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
+    // 팔로잉 목록 조회: 처음부터
+    List<Follow> findAllByFollowerIdOrderByIdAtDesc(UUID followerId, Pageable pageable);
+
+    // 팔로잉 목록 조회: idAfter부터
+    List<Follow> findAllByFollowerIdAndIdLessThenOrderByIdAtDesc(UUID followerId, UUID idAfter, Pageable pageable);
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/repository/FollowRepositoryQueryDSL.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/repository/FollowRepositoryQueryDSL.java
@@ -1,0 +1,67 @@
+package com.part4.team09.otboo.module.domain.follow.repository;
+
+import com.part4.team09.otboo.module.domain.follow.entity.Follow;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.part4.team09.otboo.module.domain.follow.entity.QFollow.follow;
+import static com.part4.team09.otboo.module.domain.user.entity.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class FollowRepositoryQueryDSL {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 검색 O : QueryDSL
+
+    // 검색어 팔로잉 목록 조회: idAfter가 null이면 처음부터 반환, null이 아니면 커서페이징대로 진행
+    public List<Follow> searchFollowings(UUID followerId, UUID idAfter, String nameLike, Pageable pageable) {
+        return queryFactory
+                .selectFrom(follow)
+                .join(user).on(follow.followeeId.eq(user.id))
+                .where(
+                        follow.followerId.eq(followerId),
+                        user.name.likeIgnoreCase("%" + nameLike + "%"),
+                        cursorCondition(idAfter) // null일 때 처리를 위해 메서드로 따로 뺐습니다
+                )
+                .orderBy(follow.id.desc())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+
+    // 검색어 팔로잉 목록 개수 (totalCount)
+    public int countSearchedFollowings(UUID followerId, String nameLike){
+        Long count = queryFactory
+                .select(follow.count())
+                .from(follow)
+                .join(user).on(follow.followeeId.eq(user.id))
+                .where(
+                        follow.followerId.eq(followerId),
+                        user.name.likeIgnoreCase("%" + nameLike + "%")
+                )
+                .fetchOne();
+
+        return count != null ? Math.toIntExact(count) : 0;
+        // SQL 에선 count를 BIGINT로 반환하는데 QueryDSL은 이를 Long으로 받아옴. 그래서 toIntExact메서드로 int로 변환
+        // (int)(long)count 캐스팅은 범위 초과시 에러를 던지지 않는데 toIntExact는 던지기 때문에 더 안전한 방법
+    }
+
+
+    // 검색어 팔로잉 조회 커서조건
+    private BooleanExpression cursorCondition(UUID idAfter) {
+        if (idAfter == null) {
+            return null;
+        }
+
+        return follow.id.lt(idAfter); // id 내림차순이니까 id가 idAfter 커서보다 작은 경우
+    }
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
@@ -1,17 +1,23 @@
 package com.part4.team09.otboo.module.domain.follow.service;
 
 import com.part4.team09.otboo.module.domain.follow.dto.FollowDto;
+import com.part4.team09.otboo.module.domain.follow.dto.FollowListResponse;
 import com.part4.team09.otboo.module.domain.follow.entity.Follow;
+import com.part4.team09.otboo.module.domain.follow.exception.NegativeLimitNotAllowed;
 import com.part4.team09.otboo.module.domain.follow.exception.SelfFollowNotAllowedException;
 import com.part4.team09.otboo.module.domain.follow.mapper.FollowMapper;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepository;
+import com.part4.team09.otboo.module.domain.follow.repository.FollowRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
-import java.util.UUID;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -20,8 +26,10 @@ public class FollowService {
 
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
+    private final FollowRepositoryQueryDSL followRepositoryQueryDSL;
     private final FollowMapper followMapper;
 
+    // 팔로우 등록
     public FollowDto create(UUID followeeId, UUID followerId){
         // 예외처리 1. existsById시 유저가 존재 x    2. 자기자신은 팔로우 불가
         if(!userRepository.existsById(followeeId)){
@@ -31,18 +39,93 @@ public class FollowService {
             throw new SelfFollowNotAllowedException(followeeId);
         }
 
-
-        log.debug("팔로우 생성 시작: follower={}, followee={}", followerId, followeeId);
+        log.info("팔로우 생성 시작: follower={}, followee={}", followerId, followeeId);
 
         Follow follow = Follow.create(followeeId, followerId);
         Follow savedFollow = followRepository.save(follow);
 
         log.info("팔로우 저장 완료: id={}", savedFollow.getId());
 
-        // 당한 사람한테 알림 발송
+        // 팔로우 당한 사람(팔로이)한테 알림 발송
 
 
         return followMapper.toDto(savedFollow);
+    }
+
+
+    // TODO: 팔로잉 목록 조회 (클라이언트에선 cursor을 받았지만 여기 서비스 파라미터에서는 제외함)
+    public FollowListResponse getFollowings(UUID followerId, UUID idAfter, int limit, String nameLike){
+
+        log.info("팔로잉 목록 조회 시작: followerId={}, idAfter={}, limit={}, nameLike={}", followerId, idAfter, limit, nameLike);
+
+        // limit 예외처리
+        if (limit <= 0) {
+            throw new NegativeLimitNotAllowed(limit);
+        }
+
+        // JPQL 쿼리문에 페이징할 사이즈를 전달하기 위한 pageable 객체
+        Pageable pageable = PageRequest.of(0, limit+1);
+
+        List<Follow> pagedFollowList;
+        int totalCount;
+        // 검색어가 있느냐 없느냐로 분기하여 팔로잉 목록 조회 시작
+        if (nameLike == null){ // 검색어 X -> 전체 팔로잉 목록 페이징
+            log.debug("검색어 없이 전체 팔로잉 목록 카운트 시작");
+
+            totalCount = followRepository.countAllFollowings(followerId);
+            pagedFollowList = followRepository.getAllFollowings(followerId, idAfter, pageable);
+
+            log.debug("전체 팔로잉 카운트: {}", totalCount);
+
+        }else{ // 검색어 O -> 일부 목록 페이징
+            log.debug("검색 팔로잉 목록 카운트 시작");
+
+            totalCount = followRepositoryQueryDSL.countSearchedFollowings(followerId, nameLike);
+            pagedFollowList = followRepositoryQueryDSL.searchFollowings(followerId, idAfter, nameLike, pageable);
+
+            log.debug("검색 팔로잉 카운트: {}", totalCount);
+            }
+
+
+        // (limit+1)개만큼 가져온 이유는 hasNext를 계산하기 위함. (limit+1)개를 followList에 저장했기 때문에 사이즈가 limit보다 크다면 hasNext가 true인 것
+        // hasNext 판단 후, 진짜 data는 (limit)개만큼 subList로 가져오기
+        boolean hasNext = pagedFollowList.size() > limit;
+        if(hasNext){
+            pagedFollowList = pagedFollowList.subList(0, limit);
+        }
+
+        // 필로잉 목록 데이터 Dto 변환
+        List<FollowDto> pagedFollowDtoList = pagedFollowList.stream()
+                .map(followMapper::toDto)
+                .collect(Collectors.toList());
+
+
+        // 다음 커서 생성
+        UUID nextIdAfter = null;
+
+        if (hasNext && !pagedFollowList.isEmpty()) { // pagedFollowList NPE 방지하기
+            nextIdAfter = pagedFollowList.get(limit - 1).getId();
+        }
+
+        String nextCursor = encodeIdAfterToCursor(nextIdAfter); // cursor는 idAfter을 Base64로 인코딩해서 만듭니다
+
+        log.debug("hasNext: {}, 실제 반환 개수: {}", hasNext, pagedFollowList.size());
+        log.debug("nextCursor: {}", nextCursor);
+        log.info("팔로잉 목록 조회 끝");
+
+        // 팔로잉 목록 조회에서는 클라이언트가 정렬 조건과 순서를 지정하지 않기 때문에 개발단에서 지정한 걸로 명시해서 반환 (id 기준, DESCENDING)
+        return new FollowListResponse(pagedFollowDtoList, nextCursor, nextIdAfter, hasNext, totalCount,"id", FollowListResponse.SortDirection.DESCENDING);
+    }
+
+    // cursor 인코딩 로직
+    private String encodeIdAfterToCursor(UUID idAfter){
+        if (idAfter == null){
+            return null;
+        }
+        String uuidStr = idAfter.toString();
+        byte[] bytes = uuidStr.getBytes(StandardCharsets.UTF_8);
+        String cursor = Base64.getEncoder().encodeToString(bytes);
+        return cursor;
     }
 
 }

--- a/src/test/java/com/part4/team09/otboo/module/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/follow/service/FollowServiceTest.java
@@ -1,9 +1,12 @@
 package com.part4.team09.otboo.module.domain.follow.service;
 
 import com.part4.team09.otboo.module.domain.follow.dto.FollowDto;
+import com.part4.team09.otboo.module.domain.follow.dto.FollowListResponse;
 import com.part4.team09.otboo.module.domain.follow.entity.Follow;
+import com.part4.team09.otboo.module.domain.follow.exception.NegativeLimitNotAllowed;
 import com.part4.team09.otboo.module.domain.follow.mapper.FollowMapper;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepository;
+import com.part4.team09.otboo.module.domain.follow.repository.FollowRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.user.dto.UserSummary;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -14,10 +17,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,6 +42,9 @@ class FollowServiceTest {
 
     @Mock
     private FollowMapper followMapper;
+
+    @Mock
+    private FollowRepositoryQueryDSL followRepositoryQueryDSL;
 
 
     @Test
@@ -68,6 +77,80 @@ class FollowServiceTest {
         assertThat(result.follower().userId()).isEqualTo(followerId);
 
         verify(followRepository).save(any(Follow.class)); // save 메서드가 호출되었는지 확인
+    }
+
+    @Test
+    @DisplayName("검색어 없이 팔로잉 목록 조회 성공")
+    void getAllFollowingsWithoutSearch() {
+        // given
+        UUID followerId = UUID.randomUUID();
+        UUID idAfter = UUID.randomUUID();
+        int limit = 1;
+
+        Follow follow = Follow.create(UUID.randomUUID(), followerId);
+        UUID followId = UUID.randomUUID();
+        ReflectionTestUtils.setField(follow, "id", followId);
+        List<Follow> follows = List.of(follow, Follow.create(UUID.randomUUID(), followerId));
+
+        // 전체 개수 5로 지정해줌
+        when(followRepository.countAllFollowings(followerId)).thenReturn(5);
+        // 팔로우 목록 반환하도록 지정
+        when(followRepository.getAllFollowings(eq(followerId), eq(idAfter), any())).thenReturn(follows);
+        // Dto 변환로직 지정
+        when(followMapper.toDto(any())).thenReturn(new FollowDto(followId,
+                new UserSummary(UUID.randomUUID(), "followee", null),
+                new UserSummary(followerId, "follower", null)));
+
+        // when
+        FollowListResponse result = followService.getFollowings(followerId, idAfter, limit, null);
+
+        // then
+        assertThat(result.data()).hasSize(1);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.totalCount()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("검색어 포함 팔로잉 목록 조회 성공")
+    void searchFollowings() {
+        // given
+        UUID followerId = UUID.randomUUID();
+        UUID idAfter = UUID.randomUUID();
+        int limit = 1;
+        String nameLike = "연경";
+
+        Follow follow = Follow.create(UUID.randomUUID(), followerId);
+        UUID followId = UUID.randomUUID();
+        ReflectionTestUtils.setField(follow, "id", followId);
+        List<Follow> follows = List.of(follow, Follow.create(UUID.randomUUID(), followerId));
+
+        // 검색 개수 1로 지정해줌
+        when(followRepositoryQueryDSL.countSearchedFollowings(followerId, nameLike)).thenReturn(1);
+        // 팔로우 목록 반환하도록 지정
+        when(followRepositoryQueryDSL.searchFollowings(eq(followerId), eq(idAfter), eq(nameLike), any())).thenReturn(follows);
+        // Dto 변환로직 지정
+        when(followMapper.toDto(any())).thenReturn(new FollowDto(followId,
+                new UserSummary(UUID.randomUUID(), "followee", null),
+                new UserSummary(followerId, "follower", null)));
+
+        // when
+        FollowListResponse result = followService.getFollowings(followerId, idAfter, limit, nameLike);
+
+        // then
+        assertThat(result.data()).hasSize(1);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.totalCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("limit 0 이하 예외")
+    void getAllFollowingsWithNegativeLimit() {
+        // given
+        UUID followerId = UUID.randomUUID();
+
+        // when, then: 예외 처리 반환되도록
+        assertThatThrownBy(() -> followService.getFollowings(followerId, null, 0, null))
+                .isInstanceOf(NegativeLimitNotAllowed.class);
     }
 
 }


### PR DESCRIPTION
## Issue Number
22 

## 요약(Summary)
- 팔로잉 목록 조회 구현
- 페이징 구현
- 서비스 단위테스트

## PR 유형
feature

어떤 변경 사항이 있나요?


- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

## 스크린샷 (선택)
[서비스 테스트]
![image](https://github.com/user-attachments/assets/718af566-09a5-4f09-8d18-883e8e519429)

[포스트맨 테스트]
- 전체 팔로잉 목록 그냥 조회
[전체.zip](https://github.com/user-attachments/files/20941680/default.zip)
- 사진과 같이 커서 입력 후 조회
![image](https://github.com/user-attachments/assets/dd402442-bca6-4f0c-bce0-a297228fdae1)
[cursor 입력 결과.zip](https://github.com/user-attachments/files/20941694/cursor.zip)
- '은' 검색: '은'자가 들어가는 값은 4개라 totalCount=4이지만 limit을 2로 설정해둬서 2개의 값만 출력됩니다.
![image](https://github.com/user-attachments/assets/ea97290b-7e33-4587-b8ec-94825d51440d)
- '근영' 검색
![image](https://github.com/user-attachments/assets/2b7cfa3f-0d73-4c8d-a20e-a822d412cba2)
- limit이 음수일 때
![image](https://github.com/user-attachments/assets/d4567c4d-fe2d-46bf-862e-53aa530503b8)

## 공유사항 to 리뷰어
- 검색 쿼리 QueryDSL 사용
팔로잉 목록 내 이름으로 검색이 돼야하지만 follow 테이블에는 followee, follower의 id만 저장되어 있고, 저희가 따로 연관관계를 맺지 않기로 했기 때문에 일반 JPA 쿼리로는 name을 불러올 수 없었습니다.
그래서 어떻게 할지 찾아보던 중 https://jojoldu.tistory.com/396 해당 블로그를 참고해 검색용 쿼리는 QueryDSL로 join을 해줬습니다. 
추후 이름뿐만 아니라 다른 조건으로 검색했을 때 동적 쿼리 작성으로 확장하기에도 좋을 거라 생각했습니다. 

- QueryDSL 내 queryFactory를 빈등록해주기 위해 config에 QueryDslConfig 추가했습니다.

- 클라이언트가 cursor, idAfter 둘 다 전달해주는 의문
한가지 의문이 드는 건 제가 이전에 할 때는 클라이언트에서 cursor 형식으로 전달해주면 이걸 UUID idAfter로 디코딩하는 로직을 썼었는데 (찾아보니 통상적으로 커서로만 들어오면 서비스단에서 디코딩을 한다고 합니다) 스웨거에서보니 클라이언트가 idAfter까지 전달을 해주길래 디코딩 로직은 뺐습니다. 그리고 컨트롤러에서 cursor을 받긴 하는데 서비스 파라미터에선 불필요해서 뺐습니다. 이 부분 피드백주시면 감사하겠습니다😃 
![image](https://github.com/user-attachments/assets/82565ffd-e0d6-4f15-a3c1-73ff6105492a)

**피드백 후>>>**
- 서비스에 검색어 유무에 따른 분기 로직 지우고, QueryDSL로 통일했습니다
- UUID v4로는 시간 정보가 안담겨 그냥 랜덤생성이니까 단일 정렬 기준으로 삼기에 문제가 있어서 이 부분 수정했습니다. 서비스 로직에 createdAtAfter를 idAfter을 통해 추출하는 코드를 추가해서 시간순으로 우선 정렬하고 겹칠 시 id로 걸러지도록 중복기준을 설정했습니다. 
- UUID v7 라이브러리를 쓰면 시간 정보가 담겨서 정렬 기준으로 삼을 수 있는데 이러면 전체 엔티티부분에 수정이 필요할 것 같아 일단 도입안했습니다. 추후 리팩토링 해봐도 좋을 것 같습니다
(참고자료)
https://goodahn.tistory.com/314
https://nozee.tistory.com/46
https://www.reddit.com/r/java/comments/1j0xn1s/lack_of_builtin_support_for_uuid_v7/?tl=ko 
- 관련 테스트 모두 다시 시행했습니다.

## Close Issue
close #22