### PR TITLE
Feature: 팔로워 목록 조회 구현

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/contoller/FollowController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/contoller/FollowController.java
@@ -47,4 +47,21 @@ public class FollowController {
                 .status(HttpStatus.OK)
                 .body(response);
     }
+
+    // 팔로워 목록 조회
+    @GetMapping("/followers")
+    public ResponseEntity<FollowListResponse> getFollowers(
+            @RequestParam UUID followeeId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) UUID idAfter,
+            @RequestParam(defaultValue = "10") Integer limit,
+            @RequestParam(required = false) String nameLike
+    ){
+
+        FollowListResponse response = followService.getFollowers(followeeId, idAfter, limit, nameLike);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
 }


### PR DESCRIPTION
## Issue Number

## 요약(Summary)

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)
[서비스 테스트]
![image](https://github.com/user-attachments/assets/d5bd2398-c32b-4b3c-97b0-a325a56f8fb7)

[포스트맨 테스트]
- 전체 팔로워 목록 그냥 조회
- 사진과 같이 커서 입력 후 조회
[팔로워_전체,커서.zip](https://github.com/user-attachments/files/20973557/_.zip)
- '은' 검색: '은'자가 들어가는 값은 2개라 totalCount=2이지만 limit을 1로 설정해둬서 1개의 값만 출력됩니다
![image](https://github.com/user-attachments/assets/43916cf3-7126-4945-bd00-535387e14a3b)

## 공유사항 to 리뷰어
- 팔로워 리스트 조회도 팔로잉 리스트와 똑같이 구현했습니다.
- UUID v4로는 시간 정보가 안담겨 그냥 랜덤생성이니까 단일 정렬 기준으로 삼기에 문제가 있어서 이 부분 수정했습니다. 서비스 로직에 createdAtAfter를 idAfter을 통해 추출하는 코드를 추가해서 시간순으로 우선 정렬하고 겹칠 시 id로 걸러지도록 중복기준을 설정했습니다.
- UUID v7 라이브러리를 쓰면 시간 정보가 담겨서 정렬 기준으로 삼을 수 있는데 이러면 전체 엔티티부분에 수정이 필요할 것 같아 일단 도입안했습니다. 추후 리팩토링 해봐도 좋을 것 같습니다
(참고자료)
https://goodahn.tistory.com/314
https://nozee.tistory.com/46
https://www.reddit.com/r/java/comments/1j0xn1s/lack_of_builtin_support_for_uuid_v7/?tl=ko

## Close Issue

close #38