### PR TITLE
Feature: 의상 속성 정의 조회 구현

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/common/enums/SortDirection.java
+++ b/src/main/java/com/part4/team09/otboo/module/common/enums/SortDirection.java
@@ -1,0 +1,5 @@
+package com.part4.team09.otboo.module.common.enums;
+
+public enum SortDirection {
+  ASCENDING, DESCENDING
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/controller/ClothesAttributeDefController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/controller/ClothesAttributeDefController.java
@@ -1,8 +1,11 @@
 package com.part4.team09.otboo.module.domain.clothes.controller;
 
+import com.part4.team09.otboo.module.common.enums.SortDirection;
 import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDefDto;
 import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefCreateRequest;
+import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefFindRequest;
 import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefUpdateRequest;
+import com.part4.team09.otboo.module.domain.clothes.dto.response.ClothesAttributeDefDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.clothes.service.ClothesAttributeInfoService;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -11,11 +14,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,6 +42,25 @@ public class ClothesAttributeDefController {
 
     log.info("의상 속성 정의 생성 응답: {}", HttpStatus.CREATED.value());
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  // 의상 속성 정의 조회
+  @GetMapping
+  ResponseEntity<ClothesAttributeDefDtoCursorResponse> findByCursor(
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) UUID idAfter,
+      @RequestParam int limit,
+      @RequestParam(defaultValue = "name") String sortBy,
+      @RequestParam(defaultValue = "ASCENDING") SortDirection sortDirection,
+      @RequestParam(required = false) String keywordLike
+  ) {
+
+    ClothesAttributeDefFindRequest request = new ClothesAttributeDefFindRequest(
+        cursor, idAfter, limit, sortBy, sortDirection, keywordLike);
+
+    ClothesAttributeDefDtoCursorResponse response = clothesAttributeInfoService.findByCursor(request);
+
+    return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 
   // 의상 속성 정의 수정
@@ -61,4 +85,5 @@ public class ClothesAttributeDefController {
     log.info("의상 속성 정의 삭제 응답: {}", HttpStatus.NO_CONTENT.value());
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
+
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesAttributeDefFindRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesAttributeDefFindRequest.java
@@ -1,0 +1,16 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.request;
+
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+import java.util.UUID;
+
+public record ClothesAttributeDefFindRequest(
+
+    String cursor,
+    UUID idAfter,
+    int limit,
+    String sortBy,
+    SortDirection sortDirection,
+    String keywordLike
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/response/ClothesAttributeDefDtoCursorResponse.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/response/ClothesAttributeDefDtoCursorResponse.java
@@ -1,0 +1,32 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.response;
+
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDefDto;
+import java.util.List;
+import java.util.UUID;
+
+public record ClothesAttributeDefDtoCursorResponse(
+
+    // 의상 속성 정의 dto 리스트
+    List<ClothesAttributeDefDto> data,
+
+    // 다음 커서
+    String nextCursor,
+
+    // 다음 요청의 보조 커서
+    UUID nextIdAfter,
+
+    // 다음 데이터가 있는지 여부
+    boolean hasNext,
+
+    // 총 데이터 개수
+    int totalCount,
+
+    // 정렬 기준
+    String sortBy,
+
+    // 정렬 방향
+    SortDirection sortDirection
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/response/ClothesDtoCursorResponse.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/response/ClothesDtoCursorResponse.java
@@ -1,0 +1,33 @@
+package com.part4.team09.otboo.module.domain.clothes.dto.response;
+
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesDto;
+import java.util.List;
+import java.util.UUID;
+
+public record ClothesDtoCursorResponse(
+
+    // 의상 정보
+    List<ClothesDto> data,
+
+    // 다음 커서
+    String nextCursor,
+
+    // 다음 요청의 보조 커서
+    UUID nextIdAfter,
+
+    // 다음 데이터가 있는지 여부
+    boolean hasNext,
+
+    // 총 데이터 개수
+    int totalCount,
+
+    // 정렬 기준
+    String sortBy,
+
+    // 정렬 방향
+    SortDirection sortDirection
+
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/mapper/ClothesAttributeDefDtoCursorResponseMapper.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/mapper/ClothesAttributeDefDtoCursorResponseMapper.java
@@ -1,0 +1,19 @@
+package com.part4.team09.otboo.module.domain.clothes.mapper;
+
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDefDto;
+import com.part4.team09.otboo.module.domain.clothes.dto.response.ClothesAttributeDefDtoCursorResponse;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClothesAttributeDefDtoCursorResponseMapper {
+
+  public ClothesAttributeDefDtoCursorResponse toDto(List<ClothesAttributeDefDto> data,
+      String nextCursor, UUID nextIdAfter, boolean hasNext, int totalCount, String sortBy, SortDirection sortDirection) {
+
+    return new ClothesAttributeDefDtoCursorResponse(data, nextCursor, nextIdAfter, hasNext, totalCount, sortBy, sortDirection);
+  }
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepository.java
@@ -10,6 +10,8 @@ public interface SelectableValueRepository extends JpaRepository<SelectableValue
 
   List<SelectableValue> findAllByAttributeDefId(UUID defId);
 
+  List<SelectableValue> findAllByAttributeDefIdIn(List<UUID> defIds);
+
   void deleteAllByAttributeDefId(UUID attributeDefId);
 
   void deleteByIdIn(List<UUID> valueIdsForDelete);

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSL.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSL.java
@@ -1,0 +1,106 @@
+package com.part4.team09.otboo.module.domain.clothes.repository.custom;
+
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefFindRequest;
+import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
+import com.part4.team09.otboo.module.domain.clothes.entity.QClothesAttributeDef;
+import com.part4.team09.otboo.module.domain.clothes.entity.QSelectableValue;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ClothesAttributeDefRepositoryQueryDSL {
+
+  private final JPAQueryFactory queryFactory;
+  QClothesAttributeDef def = QClothesAttributeDef.clothesAttributeDef;
+  QSelectableValue value = QSelectableValue.selectableValue;
+
+  // 속성 정의, 속성 값에 키워드가 있을 경우의 defId 찾기
+  public List<UUID> findDefIdsByKeyword(String keyword) {
+
+    return queryFactory
+        .select(def.id)
+        .from(def)
+        // 속성 값과 조인
+        .leftJoin(value).on(value.attributeDefId.eq(def.id))
+        .where(
+            def.name.containsIgnoreCase(keyword)
+                .or(value.item.containsIgnoreCase(keyword))
+        )
+        .distinct()
+        .fetch();
+  }
+
+  public List<ClothesAttributeDef> findByCursor(Set<UUID> defIds
+      , ClothesAttributeDefFindRequest request) {
+
+    BooleanBuilder where = new BooleanBuilder();
+
+    where.and(def.id.in(defIds));
+
+    if (request.cursor() != null && request.idAfter() != null) {
+      if (request.sortBy().equals("name")) {
+        if (request.sortDirection() == SortDirection.ASCENDING) {
+          // 오름차순일 경우 큰 값
+          where.and(
+              def.name.gt(request.cursor())
+                  .or(def.name.eq(request.cursor()).and(def.id.gt(request.idAfter())))
+          );
+        } else {
+          // 내림차순일 경우 작은 값
+          where.and(
+              def.name.lt(request.cursor())
+                  .or(def.name.eq(request.cursor()).and(def.id.lt(request.idAfter())))
+          );
+        }
+      } else {
+        LocalDateTime createdAt = LocalDateTime.parse(request.cursor());
+
+        if (request.sortDirection() == SortDirection.ASCENDING) {
+          where.and(
+              def.createdAt.gt(createdAt)
+                  .or(def.createdAt.eq(createdAt).and(def.id.gt(request.idAfter())))
+          );
+        } else {
+          where.and(
+              def.createdAt.lt(createdAt)
+                  .or(def.createdAt.eq(createdAt).and(def.id.lt(request.idAfter())))
+          );
+        }
+      }
+    }
+
+
+    OrderSpecifier<?> order = getOrderSpecifier(request);
+
+    return queryFactory
+        .selectFrom(def)
+        .where(where)
+        .orderBy(order)
+        .limit(request.limit() + 1)
+        .fetch();
+  }
+
+
+  private OrderSpecifier<?> getOrderSpecifier(ClothesAttributeDefFindRequest request) {
+    if (request.sortBy().equals("name")) {
+      return request.sortDirection().equals(SortDirection.ASCENDING)
+          ? def.name.asc()
+          : def.name.desc();
+    } else {
+      return request.sortDirection().equals(SortDirection.ASCENDING)
+          ? def.createdAt.asc()
+          : def.createdAt.desc();
+    }
+  }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefService.java
@@ -1,14 +1,20 @@
 package com.part4.team09.otboo.module.domain.clothes.service;
 
+import com.part4.team09.otboo.module.common.entity.BaseEntity;
+import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefFindRequest;
 import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefAlreadyExistsException;
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefNotFoundException;
 import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
+import com.part4.team09.otboo.module.domain.clothes.repository.custom.ClothesAttributeDefRepositoryQueryDSL;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @Slf4j
@@ -17,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClothesAttributeDefService {
 
   private final ClothesAttributeDefRepository clothesAttributeDefRepository;
+  private final ClothesAttributeDefRepositoryQueryDSL clothesAttributeDefRepositoryQueryDSL;
 
   // 의상 속성 정의 명 생성
   public ClothesAttributeDef create(String name) {
@@ -33,6 +40,38 @@ public class ClothesAttributeDefService {
 
     log.debug("의상 속성 정의 명 생성 완료: defId = {}, name = {}", def.getId(), def.getName());
     return clothesAttributeDefRepository.save(def);
+  }
+
+  // 의상 속성 정의 명 찾기
+  public ClothesAttributeDef findById(UUID defId) {
+    log.debug("의상 속성 정의 명 찾기 시작: defId = {}", defId);
+
+    return clothesAttributeDefRepository.findById(defId)
+        .orElseThrow(() -> {
+          log.warn("의상 속성 정의가 존재하지 않습니다. id = {}", defId);
+          return ClothesAttributeDefNotFoundException.withId(defId);
+        });
+  }
+
+  // 키워드로 id 찾기
+  public List<UUID> findIdsByKeyword(String keyword) {
+
+    // 키워드가 없으면 전체 반환
+    if (keyword == null || keyword.isEmpty()) {
+      return clothesAttributeDefRepository.findAll().stream()
+          .map(BaseEntity::getId)
+          .toList();
+    }
+    return clothesAttributeDefRepositoryQueryDSL.findDefIdsByKeyword(keyword);
+  }
+
+  // 커서 기반 페이지네이션
+  public List<ClothesAttributeDef> findByCursor(Set<UUID> defIds, ClothesAttributeDefFindRequest request) {
+
+    if (defIds == null || defIds.isEmpty()) {
+      return List.of();
+    }
+    return clothesAttributeDefRepositoryQueryDSL.findByCursor(defIds, request);
   }
 
   // 의상 속성 정의 명 수정
@@ -52,17 +91,6 @@ public class ClothesAttributeDefService {
 
     log.debug("의상 속성 정의 명 수정 완료: defId = {}, name = {}", def.getId(), def.getName());
     return def;
-  }
-
-  // 의상 속성 정의 명 찾기
-  public ClothesAttributeDef findById(UUID defId) {
-    log.debug("의상 속성 정의 명 찾기 시작: defId = {}", defId);
-
-    return clothesAttributeDefRepository.findById(defId)
-        .orElseThrow(() -> {
-          log.warn("의상 속성 정의가 존재하지 않습니다. id = {}", defId);
-          return ClothesAttributeDefNotFoundException.withId(defId);
-        });
   }
 
   // 의상 속성 정의 명 삭제

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoService.java
@@ -4,14 +4,19 @@ package com.part4.team09.otboo.module.domain.clothes.service;
 import com.part4.team09.otboo.module.common.entity.BaseEntity;
 import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDefDto;
 import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefCreateRequest;
+import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefFindRequest;
 import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefUpdateRequest;
+import com.part4.team09.otboo.module.domain.clothes.dto.response.ClothesAttributeDefDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
 import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
+import com.part4.team09.otboo.module.domain.clothes.mapper.ClothesAttributeDefDtoCursorResponseMapper;
 import com.part4.team09.otboo.module.domain.clothes.mapper.ClothesAttributeDefMapper;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,6 +36,7 @@ public class ClothesAttributeInfoService {
   private final SelectableValueService selectableValueService;
   private final ClothesAttributeService clothesAttributeService;
   private final ClothesAttributeDefMapper clothesAttributeDefMapper;
+  private final ClothesAttributeDefDtoCursorResponseMapper clothesAttributeDefDtoCursorResponseMapper;
 
   // 의상 속성 정의 생성
   public ClothesAttributeDefDto create(ClothesAttributeDefCreateRequest request) {
@@ -40,13 +46,57 @@ public class ClothesAttributeInfoService {
     ClothesAttributeDef def = clothesAttributeDefService.create(request.name());
 
     List<String> valueItems = selectableValueService.create(def.getId(), request.selectableValues())
-        .stream()
-        .map(SelectableValue::getItem)
-        .toList();
+        .stream().map(SelectableValue::getItem).toList();
 
     log.debug("의상 속성 정의 생성 완료: defId = {}, name = {}, values = {}", def.getId(), def.getName(),
         valueItems);
     return clothesAttributeDefMapper.toDto(def.getId(), def.getName(), valueItems);
+  }
+
+  // 커서 기반 의상 속성 정의 탐색
+  public ClothesAttributeDefDtoCursorResponse findByCursor(ClothesAttributeDefFindRequest request) {
+
+    log.debug("의상 속성 정의 찾기 시작: request = {}", request);
+    // 1. 키워드에 해당하는 id 저장
+    Set<UUID> defIdSet = new HashSet<>(clothesAttributeDefService.findIdsByKeyword(request.keywordLike()));
+
+    // 2 커서 기반 페이지네이션
+    List<ClothesAttributeDef> defs = clothesAttributeDefService.findByCursor(defIdSet, request);
+
+    // 2.1 hasNext 판단, 마지막 값 제거
+    boolean hasNext = defs.size() > request.limit();
+    if (hasNext) defs = defs.subList(0, request.limit());
+
+    // 2.2 nextCursor, nextIdAfter, totalCount
+    // 다음 커서 - 프로토타입에서 다음 페이지를 나타내는 것으로 보임, 사용자 커서처럼 마지막 정의 명을 반환
+    String nextCursor = defs.get(defs.size() - 1).getName();
+    UUID nextIdAfter = defs.get(defs.size() - 1).getId();
+    int totalCount = defIdSet.size();
+
+    // 3. 2에서 가져온 def로 의상 속성 값 가져오기
+    List<UUID> defIds = defs.stream()
+        .map(BaseEntity::getId)
+        .toList();
+
+    // 4. 해당 속성 값 가져오기, dto로 변환
+    Map<UUID, List<SelectableValue>> valueMap = selectableValueService.findAllByAttributeDefIdIn(defIds).stream()
+        .collect(Collectors.groupingBy(SelectableValue::getAttributeDefId));
+
+    List<ClothesAttributeDefDto> data = defs.stream().map(
+        def -> clothesAttributeDefMapper.toDto(def.getId(), def.getName(),
+            valueMap.get(def.getId()).stream()
+                .map(SelectableValue::getItem)
+                .toList()))
+        .toList();
+
+    return clothesAttributeDefDtoCursorResponseMapper.toDto(
+        data,
+        nextCursor,
+        nextIdAfter,
+        hasNext,
+        totalCount,
+        request.sortBy(),
+        request.sortDirection());
   }
 
   // 의상 속성 정의 수정
@@ -59,8 +109,7 @@ public class ClothesAttributeInfoService {
     String oldName = def.getName();
     String newName = request.name();
 
-    return newName.equals(oldName)
-        ? updateWhenNameSame(def, request)
+    return newName.equals(oldName) ? updateWhenNameSame(def, request)
         : updateWhenNameChanged(def, request);
   }
 
@@ -71,8 +120,7 @@ public class ClothesAttributeInfoService {
     clothesAttributeDefService.findById(defId);
 
     List<UUID> valueIds = selectableValueService.findAllByAttributeDefId(defId).stream()
-        .map(BaseEntity::getId)
-        .toList();
+        .map(BaseEntity::getId).toList();
 
     // 연관된 ClothesAttribute 삭제
     clothesAttributeService.deleteBySelectableValueIdIn(valueIds);
@@ -92,8 +140,7 @@ public class ClothesAttributeInfoService {
     Set<String> newValuesSet = new HashSet<>(request.selectableValues());
 
     List<UUID> valueIdsForDelete = oldValues.stream()
-        .filter(oldValue -> !newValuesSet.contains(oldValue.getItem()))
-        .map(BaseEntity::getId)
+        .filter(oldValue -> !newValuesSet.contains(oldValue.getItem())).map(BaseEntity::getId)
         .toList();
 
     // 2. clothesAttribute 삭제
@@ -101,9 +148,7 @@ public class ClothesAttributeInfoService {
 
     // 3. 속성 값 새로 생성
     List<String> newValueItems = selectableValueService.updateWhenNameSame(def.getId(),
-            valueIdsForDelete, request.selectableValues())
-        .stream()
-        .map(SelectableValue::getItem)
+            valueIdsForDelete, request.selectableValues()).stream().map(SelectableValue::getItem)
         .toList();
 
     log.debug("의상 속성 정의 수정 완료(정의 이름 변경 X): defId = {}, name = {}, values = {}", def.getId(),
@@ -121,14 +166,11 @@ public class ClothesAttributeInfoService {
 
     // 2. clothesAttribute 삭제
     clothesAttributeService.deleteBySelectableValueIdIn(
-        oldValues.stream().map(BaseEntity::getId).toList()
-    );
+        oldValues.stream().map(BaseEntity::getId).toList());
 
     // 3. 새 속성 값 전부 생성
     List<String> newValueItems = selectableValueService.updateWhenNameChanged(updatedDef.getId(),
-            request.selectableValues()).stream()
-        .map(SelectableValue::getItem)
-        .toList();
+        request.selectableValues()).stream().map(SelectableValue::getItem).toList();
 
     log.debug("의상 속성 정의 수정 완료(정의 이름 변경 O): defId = {}, name = {}, values = {}", updatedDef.getId(),
         updatedDef.getName(), newValueItems);

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueService.java
@@ -42,6 +42,24 @@ public class SelectableValueService {
     return selectableValueRepository.saveAll(selectableValues);
   }
 
+  // 속성 정의 명에 해당되는 속성 값들 반환
+  public List<SelectableValue> findAllByAttributeDefId(UUID defId) {
+
+    validateDefId(defId);
+
+    return selectableValueRepository.findAllByAttributeDefId(defId);
+  }
+
+  // 속성 정의 id 리스트로 찾기
+  public List<SelectableValue> findAllByAttributeDefIdIn(List<UUID> defIds) {
+
+    if (defIds == null || defIds.isEmpty()) {
+      return List.of();
+    }
+
+    return selectableValueRepository.findAllByAttributeDefIdIn(defIds);
+  }
+
   public List<SelectableValue> updateWhenNameSame(UUID defId, List<UUID> valueIdsForDelete,
       List<String> newValues) {
 
@@ -92,12 +110,6 @@ public class SelectableValueService {
             .map(SelectableValue::getItem)
             .toList());
     return selectableValueRepository.saveAll(selectableValues);
-  }
-
-  // 속성 정의 명에 해당되는 속성 값들 반환
-  public List<SelectableValue> findAllByAttributeDefId(UUID defId) {
-
-    return selectableValueRepository.findAllByAttributeDefId(defId);
   }
 
   // 속성 정의 명 리스트로 삭제

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepositoryTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepositoryTest.java
@@ -59,6 +59,41 @@ class SelectableValueRepositoryTest {
   }
 
   @Nested
+  @DisplayName("정의 id 리스트로 속성 값 리스트 반환")
+  class FindAllByAttributeDefIdIn {
+
+    @Test
+    @DisplayName("성공")
+    void find_all_by_attribute_def_id_in_success() {
+
+      // given
+      UUID defId1 = UUID.randomUUID();
+      List<SelectableValue> selectableValues1 = Stream.of("S", "M", "L")
+          .map(value -> SelectableValue.create(defId1, value))
+          .toList();
+      UUID defId2 = UUID.randomUUID();
+      List<SelectableValue> selectableValues2 = Stream.of("없음", "있음", "조금 있음")
+          .map(value -> SelectableValue.create(defId2, value))
+          .toList();
+
+      List<UUID> defIds = List.of(defId1, defId2);
+
+      selectableValueRepository.saveAll(selectableValues1);
+      selectableValueRepository.saveAll(selectableValues2);
+      entityManager.flush();
+      entityManager.clear();
+
+      List<SelectableValue> selectableValues = selectableValueRepository.findAll();
+
+      // when
+      List<SelectableValue> results = selectableValueRepository.findAllByAttributeDefIdIn(defIds);
+
+      // then
+      assertEquals(results, selectableValues);
+    }
+  }
+
+  @Nested
   @DisplayName("의상 속성 정의 id로 속성 값 전부 삭제")
   class DeleteAllByAttributeDefId {
 

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSLTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSLTest.java
@@ -1,0 +1,79 @@
+package com.part4.team09.otboo.module.domain.clothes.repository.custom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.part4.team09.otboo.config.QueryDslConfig;
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefFindRequest;
+import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
+import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
+import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
+import com.part4.team09.otboo.module.domain.clothes.repository.SelectableValueRepository;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@EnableJpaAuditing
+@Import({QueryDslConfig.class, ClothesAttributeDefRepositoryQueryDSL.class})
+@ActiveProfiles("test")
+class ClothesAttributeDefRepositoryQueryDSLTest {
+
+  private static final Logger log = LoggerFactory.getLogger(
+      ClothesAttributeDefRepositoryQueryDSLTest.class);
+  @Autowired
+  private ClothesAttributeDefRepositoryQueryDSL queryDSL;
+
+  @Autowired
+  private ClothesAttributeDefRepository defRepository;
+
+  @Autowired
+  private SelectableValueRepository valueRepository;
+
+  @Test
+  void find_def_ids_by_keyword() {
+    // given
+    ClothesAttributeDef def1 = defRepository.save(ClothesAttributeDef.create("사이즈"));
+    ClothesAttributeDef def2 = defRepository.save(ClothesAttributeDef.create("색상"));
+    valueRepository.save(SelectableValue.create(def1.getId(), "S"));
+    valueRepository.save(SelectableValue.create(def1.getId(), "M"));
+    valueRepository.save(SelectableValue.create(def2.getId(), "레드"));
+
+    // when
+    List<UUID> result = queryDSL.findDefIdsByKeyword("레드");
+
+    // then
+    assertEquals(result.get(0), def2.getId());
+    assertNotEquals(result.get(0), def1.getId());
+  }
+
+  @Test
+  void find_by_cursor() {
+    // given
+    ClothesAttributeDef def1 = defRepository.save(ClothesAttributeDef.create("A"));
+    ClothesAttributeDef def2 = defRepository.save(ClothesAttributeDef.create("B"));
+    ClothesAttributeDef def3 = defRepository.save(ClothesAttributeDef.create("C"));
+
+    Set<UUID> ids = Set.of(def1.getId(), def2.getId(), def3.getId());
+    ClothesAttributeDefFindRequest request = new ClothesAttributeDefFindRequest(
+        def1.getName(), def1.getId(), 2, "name", SortDirection.ASCENDING, null
+    );
+
+    List<ClothesAttributeDef> defs = List.of(def2, def3);
+
+    // when
+    List<ClothesAttributeDef> result = queryDSL.findByCursor(ids, request);
+
+    // then
+    assertEquals(result, defs);
+  }
+}

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefServiceTest.java
@@ -6,12 +6,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
+import com.part4.team09.otboo.module.common.entity.BaseEntity;
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefFindRequest;
 import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefAlreadyExistsException;
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefNotFoundException;
 import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
+import com.part4.team09.otboo.module.domain.clothes.repository.custom.ClothesAttributeDefRepositoryQueryDSL;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,6 +37,9 @@ class ClothesAttributeDefServiceTest {
 
   @Mock
   private ClothesAttributeDefRepository clothesAttributeDefRepository;
+
+  @Mock
+  private ClothesAttributeDefRepositoryQueryDSL clothesAttributeDefRepositoryQueryDSL;
 
   @Nested
   @DisplayName("의상 속성 정의 생성")
@@ -71,6 +82,132 @@ class ClothesAttributeDefServiceTest {
   }
 
   @Nested
+  @DisplayName("의상 속성 정의 찾기")
+  class FindById {
+
+    @Test
+    @DisplayName("찾기 성공")
+    void find_by_id_success() {
+
+      // given
+      UUID id = UUID.randomUUID();
+      ClothesAttributeDef def = ClothesAttributeDef.create("사이즈");
+
+      given(clothesAttributeDefRepository.findById(id)).willReturn(Optional.of(def));
+
+      // when
+      ClothesAttributeDef result = clothesAttributeDefService.findById(id);
+
+      // then
+      assertNotNull(result);
+      assertEquals(def, result);
+      then(clothesAttributeDefRepository).should().findById(id);
+    }
+
+    @Test
+    @DisplayName("찾기 실패 - 잘못된 id")
+    void find_by_id_not_found_id() {
+
+      // given
+      UUID id = UUID.randomUUID();
+
+      given(clothesAttributeDefRepository.findById(id)).willReturn(Optional.empty());
+
+      // when, then
+      assertThrows(ClothesAttributeDefNotFoundException.class,
+          () -> clothesAttributeDefService.findById(id));
+    }
+  }
+
+  @Nested
+  @DisplayName("키워드로 속성 정의 찾기")
+  class FindIdsByKeyword {
+
+    @Test
+    @DisplayName("키워드로 찾기 성공")
+    void find_ids_by_keyword_success() {
+
+      // given
+      String keyword = "사이즈";
+      List<UUID> defIds = List.of(UUID.randomUUID());
+
+      given(clothesAttributeDefRepositoryQueryDSL.findDefIdsByKeyword(keyword)).willReturn(defIds);
+
+      // when
+      List<UUID> result = clothesAttributeDefService.findIdsByKeyword(keyword);
+
+      // then
+      assertEquals(result, defIds);
+      then(clothesAttributeDefRepository).should(times(0)).findAll();
+      then(clothesAttributeDefRepositoryQueryDSL).should().findDefIdsByKeyword(keyword);
+    }
+
+    @Test
+    @DisplayName("키워드가 없음")
+    void find_ids_by_keyword_no_keyword() {
+
+      // given
+      String keyword = "";
+      List<ClothesAttributeDef> defs = List.of(ClothesAttributeDef.create("사이즈"));
+
+      given(clothesAttributeDefRepository.findAll()).willReturn(defs);
+
+      // when
+      List<UUID> result = clothesAttributeDefService.findIdsByKeyword(keyword);
+
+      // then
+      assertEquals(result, defs.stream().map(BaseEntity::getId).toList());
+      then(clothesAttributeDefRepository).should().findAll();
+      then(clothesAttributeDefRepositoryQueryDSL).should(times(0)).findDefIdsByKeyword(keyword);
+    }
+  }
+
+  @Nested
+  @DisplayName("커서 기반 페이지네이션")
+  class FindByCursor {
+
+    @Test
+    @DisplayName("찾기 성공")
+    void find_by_cursor_success() {
+
+      // given
+      Set<UUID> defIds = new HashSet<>(List.of(UUID.randomUUID()));
+      ClothesAttributeDef def = ClothesAttributeDef.create("사이즈");
+      ClothesAttributeDefFindRequest request = new ClothesAttributeDefFindRequest(null, null, 10,
+          "name", SortDirection.ASCENDING, "사이즈");
+      List<ClothesAttributeDef> defs = List.of(def);
+
+      given(clothesAttributeDefRepositoryQueryDSL.findByCursor(defIds, request)).willReturn(
+          defs);
+      // when
+      List<ClothesAttributeDef> result = clothesAttributeDefService.findByCursor(defIds, request);
+
+      // then
+      assertEquals(result, defs);
+      then(clothesAttributeDefRepositoryQueryDSL).should().findByCursor(defIds, request);
+    }
+
+    @Test
+    @DisplayName("defIds가 없음")
+    void find_by_cursor_no_def_ids() {
+
+      // given
+      Set<UUID> defIds = Set.of();
+      ClothesAttributeDefFindRequest request = new ClothesAttributeDefFindRequest(null, null, 10,
+          "name", SortDirection.ASCENDING, "사이즈");
+      List<ClothesAttributeDef> defs = List.of();
+
+      // when
+      List<ClothesAttributeDef> result = clothesAttributeDefService.findByCursor(defIds, request);
+
+      // then
+      assertEquals(result, defs);
+      then(clothesAttributeDefRepositoryQueryDSL).should(times(0)).findByCursor(defIds, request);
+
+    }
+  }
+
+  @Nested
   @DisplayName("의상 속성 정의 수정")
   class Update {
 
@@ -106,43 +243,6 @@ class ClothesAttributeDefServiceTest {
       // when, then
       assertThrows(ClothesAttributeDefNotFoundException.class,
           () -> clothesAttributeDefService.update(defId, "신축성"));
-    }
-  }
-
-  @Nested
-  @DisplayName("의상 속성 정의 찾기")
-  class FindById {
-
-    @Test
-    @DisplayName("찾기 성공")
-    void find_by_id_success() {
-
-      // given
-      UUID id = UUID.randomUUID();
-      ClothesAttributeDef def = ClothesAttributeDef.create("사이즈");
-
-      given(clothesAttributeDefRepository.findById(id)).willReturn(Optional.of(def));
-
-      // when
-      ClothesAttributeDef result = clothesAttributeDefService.findById(id);
-
-      // then
-      assertNotNull(result);
-      assertEquals(def, result);
-      then(clothesAttributeDefRepository).should().findById(id);
-    }
-
-    @Test
-    @DisplayName("찾기 실패 - 잘못된 id")
-    void find_by_id_not_found_id() {
-
-      // given
-      UUID id = UUID.randomUUID();
-
-      given(clothesAttributeDefRepository.findById(id)).willReturn(Optional.empty());
-
-      // when, then
-      assertThrows(ClothesAttributeDefNotFoundException.class, () -> clothesAttributeDefService.findById(id));
     }
   }
 

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoServiceTest.java
@@ -90,6 +90,12 @@ class ClothesAttributeInfoServiceTest {
   }
 
   @Nested
+  @DisplayName("의상 속성 찾기")
+  class FindByCursor {
+
+  }
+
+  @Nested
   @DisplayName("의상 속성 수정")
   class Update {
 

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueServiceTest.java
@@ -81,6 +81,90 @@ class SelectableValueServiceTest {
   }
 
   @Nested
+  @DisplayName("def id로 속성 값 찾기")
+  class FindAllByAttributeDefId {
+
+    @Test
+    @DisplayName("속성 값 def id로 찾기 성공")
+    void find_all_by_attribute_def_id_success() {
+
+      // given
+      UUID defId = UUID.randomUUID();
+      List<SelectableValue> selectableValues = Stream.of("S", "M", "L")
+          .map(value -> SelectableValue.create(defId, value))
+          .toList();
+
+      given(clothesAttributeDefRepository.existsById(defId)).willReturn(true);
+      given(selectableValueRepository.findAllByAttributeDefId(defId)).willReturn(selectableValues);
+
+      // when
+      List<SelectableValue> results = selectableValueService.findAllByAttributeDefId(defId);
+
+      // then
+      assertNotNull(results);
+      assertEquals(results, selectableValues);
+      then(clothesAttributeDefRepository).should().existsById(defId);
+      then(selectableValueRepository).should().findAllByAttributeDefId(defId);
+    }
+
+    @Test
+    @DisplayName("속성 값 def id로 찾기 실패 - def가 없음")
+    void find_all_by_attribute_def_id_not_found_def() {
+
+      // given
+      UUID defId = UUID.randomUUID();
+
+      given(clothesAttributeDefRepository.existsById(defId)).willReturn(false);
+
+      // when, then
+      assertThrows(ClothesAttributeDefNotFoundException.class, () -> selectableValueService.findAllByAttributeDefId(defId));
+      then(clothesAttributeDefRepository).should().existsById(defId);
+      then(selectableValueRepository).should(times(0)).findAllByAttributeDefId(defId);
+    }
+  }
+
+  @Nested
+  @DisplayName("def id 리스트로 속성 값 찾기")
+  class findAllByAttributeDefIdIn {
+
+    @Test
+    @DisplayName("찾기 성공")
+    void find_all_by_attribute_def_id_in_success() {
+
+      // given
+      List<UUID> defIds = List.of(UUID.randomUUID());
+      List<SelectableValue> selectableValues = List.of(SelectableValue.create(defIds.get(0), "S"));
+
+      given(selectableValueRepository.findAllByAttributeDefIdIn(defIds)).willReturn(selectableValues);
+
+      // when
+      List<SelectableValue> result = selectableValueService.findAllByAttributeDefIdIn(defIds);
+
+      // then
+      assertNotNull(result);
+      assertEquals(result, selectableValues);
+      then(selectableValueRepository).should().findAllByAttributeDefIdIn(defIds);
+    }
+
+    @Test
+    @DisplayName("def id 리스트가 없음")
+    void find_all_by_attribute_def_id_in_no_def_ids() {
+
+      // given
+      List<UUID> defIds = List.of();
+      List<SelectableValue> selectableValues = List.of();
+
+      // when
+      List<SelectableValue> result = selectableValueService.findAllByAttributeDefIdIn(defIds);
+
+      // then
+      assertNotNull(result);
+      assertEquals(result, selectableValues);
+      then(selectableValueRepository).should(times(0)).findAllByAttributeDefIdIn(defIds);
+    }
+  }
+
+  @Nested
   @DisplayName("속성 값 수정")
   class Update {
 
@@ -170,32 +254,6 @@ class SelectableValueServiceTest {
       // when, then
       assertThrows(ClothesAttributeDefNotFoundException.class,
           () -> selectableValueService.updateWhenNameChanged(defId, List.of()));
-    }
-  }
-
-  @Nested
-  @DisplayName("속성 값 def id로 찾기")
-  class findAllByAttributeDefId {
-
-    @Test
-    @DisplayName("속성 값 def id로 찾기 성공")
-    void find_all_by_attribute_def_id_success() {
-
-      // given
-      UUID defId = UUID.randomUUID();
-      List<SelectableValue> selectableValues = Stream.of("S", "M", "L")
-          .map(value -> SelectableValue.create(defId, value))
-          .toList();
-
-      given(selectableValueRepository.findAllByAttributeDefId(defId)).willReturn(selectableValues);
-
-      // when
-      List<SelectableValue> results = selectableValueService.findAllByAttributeDefId(defId);
-
-      // then
-      assertNotNull(results);
-      assertEquals(results, selectableValues);
-      then(selectableValueRepository).should().findAllByAttributeDefId(defId);
     }
   }
 


### PR DESCRIPTION
## Issue Number
#45

## 요약(Summary)
- QueryDSL을 사용해 의상 속성 정의 조회를 구현했습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)

## 공유사항 to 리뷰어
- 오늘 안에 끝내려고 하다보니 로깅과 postman 테스트는 하지 못했습니다. 구현에 이상한 부분 있으면 말씀해주세요!
- 내일 로깅과 postman 테스트를 할 예정입니다.
- 자주 사용되는 SortDirection을 common/enums에 만들었습니다.
### 커서 기반 페이지네이션
1. 키워드를 통해 정의 명과 속성 값에 키워드가 포함되면 해당 defId를 반환합니다.
2. 반환된 값들을 페이지네이션을 합니다.
2.1 sortBy와 sortDirection을 기준으로 구현했습니다.
3. 가져온 정의 명에 해당하는 속성 값을 가져옵니다.

## Close Issue

close #45