### PR TITLE
Refactor: 의상 속성 정의 리팩토링

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/controller/ClothesAttributeDefController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/controller/ClothesAttributeDefController.java
@@ -54,12 +54,14 @@ public class ClothesAttributeDefController {
       @RequestParam(defaultValue = "ASCENDING") SortDirection sortDirection,
       @RequestParam(required = false) String keywordLike
   ) {
+    log.info("의상 속성 정의 조회 요청");
 
     ClothesAttributeDefFindRequest request = new ClothesAttributeDefFindRequest(
         cursor, idAfter, limit, sortBy, sortDirection, keywordLike);
 
     ClothesAttributeDefDtoCursorResponse response = clothesAttributeInfoService.findByCursor(request);
 
+    log.info("의상 속성 정의 조회 응답: {}", HttpStatus.OK.value());
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/ClothesAttributeDef/BadRequestException.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/ClothesAttributeDef/BadRequestException.java
@@ -1,0 +1,23 @@
+package com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef;
+
+import com.part4.team09.otboo.module.common.exception.CommonErrorCode;
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesException;
+
+public class BadRequestException extends ClothesException {
+
+  public BadRequestException() {
+    super(CommonErrorCode.INVALID_INPUT_VALUE);
+  }
+
+  public static BadRequestException withLimit(int limit) {
+    BadRequestException exception = new BadRequestException();
+    exception.addDetail("String", limit);
+    return exception;
+  }
+
+  public static BadRequestException withSortBy(String sortBy) {
+    BadRequestException exception = new BadRequestException();
+    exception.addDetail("sortBy", sortBy);
+    return exception;
+  }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSL.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSL.java
@@ -10,7 +10,6 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSL.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSL.java
@@ -41,7 +41,7 @@ public class ClothesAttributeDefRepositoryQueryDSL {
         .fetch();
   }
 
-  public List<ClothesAttributeDef> findByCursor(Set<UUID> defIds
+  public List<ClothesAttributeDef> findByCursor(List<UUID> defIds
       , ClothesAttributeDefFindRequest request) {
 
     BooleanBuilder where = new BooleanBuilder();

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefService.java
@@ -8,7 +8,6 @@ import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDe
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefNotFoundException;
 import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
 import com.part4.team09.otboo.module.domain.clothes.repository.custom.ClothesAttributeDefRepositoryQueryDSL;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefService.java
@@ -3,10 +3,12 @@ package com.part4.team09.otboo.module.domain.clothes.service;
 import com.part4.team09.otboo.module.common.entity.BaseEntity;
 import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefFindRequest;
 import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.BadRequestException;
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefAlreadyExistsException;
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefNotFoundException;
 import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
 import com.part4.team09.otboo.module.domain.clothes.repository.custom.ClothesAttributeDefRepositoryQueryDSL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -14,13 +16,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 @Service
 @Slf4j
 @Transactional
 @RequiredArgsConstructor
 public class ClothesAttributeDefService {
+
+  private static final Set<String> VALID_SORT_BY = Set.of("name", "createdAt");
 
   private final ClothesAttributeDefRepository clothesAttributeDefRepository;
   private final ClothesAttributeDefRepositoryQueryDSL clothesAttributeDefRepositoryQueryDSL;
@@ -38,40 +41,72 @@ public class ClothesAttributeDefService {
 
     ClothesAttributeDef def = ClothesAttributeDef.create(name);
 
-    log.debug("의상 속성 정의 명 생성 완료: defId = {}, name = {}", def.getId(), def.getName());
-    return clothesAttributeDefRepository.save(def);
+    ClothesAttributeDef savedDef = clothesAttributeDefRepository.save(def);
+
+    log.debug("의상 속성 정의 명 생성 완료: defId = {}, name = {}", savedDef.getId(), savedDef.getName());
+    return savedDef;
   }
 
   // 의상 속성 정의 명 찾기
   public ClothesAttributeDef findById(UUID defId) {
-    log.debug("의상 속성 정의 명 찾기 시작: defId = {}", defId);
+    log.debug("의상 속성 정의 명 조회 시작: defId = {}", defId);
 
-    return clothesAttributeDefRepository.findById(defId)
+    ClothesAttributeDef def = clothesAttributeDefRepository.findById(defId)
         .orElseThrow(() -> {
-          log.warn("의상 속성 정의가 존재하지 않습니다. id = {}", defId);
-          return ClothesAttributeDefNotFoundException.withId(defId);
+            log.warn("의상 속성 정의가 존재하지 않습니다. id = {}", defId);
+            return ClothesAttributeDefNotFoundException.withId(defId);
         });
+
+    log.debug("의상 속성 정의 명 조회 완료: defId = {}, name = {}", def.getId(), def.getName());
+    return def;
   }
 
   // 키워드로 id 찾기
   public List<UUID> findIdsByKeyword(String keyword) {
 
+    log.debug("의상 속성 키워드로 조회 시작: keyword = {}", keyword);
+
+    List<UUID> defIds;
     // 키워드가 없으면 전체 반환
     if (keyword == null || keyword.isEmpty()) {
-      return clothesAttributeDefRepository.findAll().stream()
+
+      defIds = clothesAttributeDefRepository.findAll().stream()
           .map(BaseEntity::getId)
           .toList();
+
+      log.debug("키워드가 없어 모든 defIds를 반환합니다: defIdsSize = {}", defIds.size());
+      return defIds;
     }
-    return clothesAttributeDefRepositoryQueryDSL.findDefIdsByKeyword(keyword);
+
+    defIds = clothesAttributeDefRepositoryQueryDSL.findDefIdsByKeyword(keyword);
+    log.debug("의상 속성 키워드로 조회 완료: defIdsSize = {}", defIds.size());
+    return defIds;
   }
 
   // 커서 기반 페이지네이션
-  public List<ClothesAttributeDef> findByCursor(Set<UUID> defIds, ClothesAttributeDefFindRequest request) {
+  public List<ClothesAttributeDef> findByCursor(List<UUID> defIds,
+      ClothesAttributeDefFindRequest request) {
 
-    if (defIds == null || defIds.isEmpty()) {
+    log.debug("의상 속성 페이지네이션 시작: defIdsSize = {}, request = {}", defIds.size(), request);
+
+    if (request.limit() <= 0) {
+      log.warn("유효하지 않은 limit입니다.: limit = {}", request.limit());
+      throw BadRequestException.withLimit(request.limit());
+    }
+
+    if (!VALID_SORT_BY.contains(request.sortBy())) {
+      log.warn("잘못된 sortBy입니다: validSortBy = {}, sortBy = {}", VALID_SORT_BY, request.sortBy());
+      throw BadRequestException.withSortBy(request.sortBy());
+    }
+
+    if (defIds.isEmpty()) {
+      log.debug("defIds가 비어있습니다. return = {}", List.of());
       return List.of();
     }
-    return clothesAttributeDefRepositoryQueryDSL.findByCursor(defIds, request);
+
+    List<ClothesAttributeDef> defs = clothesAttributeDefRepositoryQueryDSL.findByCursor(defIds, request);
+    log.debug("의상 속성 페이지네이션 완료: defsSize = {}", defs.size());
+    return defs;
   }
 
   // 의상 속성 정의 명 수정
@@ -80,11 +115,10 @@ public class ClothesAttributeDefService {
     log.debug("의상 속성 정의 명 수정 시작: defId = {}, newName = {}", defId, newName);
 
     // id 검사
-    ClothesAttributeDef def = clothesAttributeDefRepository.findById(defId)
-        .orElseThrow(() -> {
-          log.warn("의상 속성 정의가 존재하지 않습니다. id = {}", defId);
-          return ClothesAttributeDefNotFoundException.withId(defId);
-        });
+    ClothesAttributeDef def = clothesAttributeDefRepository.findById(defId).orElseThrow(() -> {
+      log.warn("의상 속성 정의가 존재하지 않습니다. id = {}", defId);
+      return ClothesAttributeDefNotFoundException.withId(defId);
+    });
 
     // 이름 변경
     def.update(newName);
@@ -97,6 +131,14 @@ public class ClothesAttributeDefService {
   public void delete(UUID defId) {
     log.debug("의상 속성 정의 명 삭제 시작: defId = {}", defId);
 
+    clothesAttributeDefRepository.findById(defId)
+        .orElseThrow(() -> {
+          log.warn("의상 속성 정의가 존재하지 않습니다. id = {}", defId);
+          return ClothesAttributeDefNotFoundException.withId(defId);
+        });
+
     clothesAttributeDefRepository.deleteById(defId);
+
+    log.debug("의상 속성 정의 명 삭제 완료");
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeService.java
@@ -17,8 +17,10 @@ public class ClothesAttributeService {
   private final ClothesAttributeRepository clothesAttributeRepository;
 
   public void deleteBySelectableValueIdIn(List<UUID> valueIds) {
-    log.debug("의상 속성 값 - 의상 연관 삭제: valueIds = {}", valueIds);
+    log.debug("의상 속성 값 - 의상 연관 삭제 시작: valueIdsSize = {}", valueIds.size());
 
     clothesAttributeRepository.deleteBySelectableValueIdIn(valueIds);
+
+    log.debug("의상 속성 값 - 의상 연관 삭제 완료");
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueService.java
@@ -24,7 +24,7 @@ public class SelectableValueService {
 
   public List<SelectableValue> create(UUID defId, List<String> values) {
 
-    log.debug("의상 속성 명 생성 시작: defId = {}, values = {}", defId, values);
+    log.debug("의상 속성 명 생성 시작: defId = {}, valuesSize = {}", defId, values.size());
 
     // id 검사
     validateDefId(defId);
@@ -34,36 +34,46 @@ public class SelectableValueService {
       .map(value -> SelectableValue.create(defId, value))
       .toList();
 
-    log.debug("의상 속성 명 생성 완료: defId = {}, values = {}", defId,
-        selectableValues.stream()
-            .map(SelectableValue::getItem)
-            .toList());
+    List<SelectableValue> response = selectableValueRepository.saveAll(selectableValues);
 
-    return selectableValueRepository.saveAll(selectableValues);
+    log.debug("의상 속성 명 생성 완료: defId = {}, values = {}", defId,
+        response.size());
+    return response;
   }
 
   // 속성 정의 명에 해당되는 속성 값들 반환
   public List<SelectableValue> findAllByAttributeDefId(UUID defId) {
 
+    log.debug("의상 속성 정의 id로 속성 값 조회 시작: defId = {}", defId);
+
     validateDefId(defId);
 
-    return selectableValueRepository.findAllByAttributeDefId(defId);
+    List<SelectableValue> response = selectableValueRepository.findAllByAttributeDefId(defId);
+
+    log.debug("의상 속성 정의 명으로 속성 값 조회 완료: valuesSize = {}", response.size());
+    return response;
   }
 
   // 속성 정의 id 리스트로 찾기
   public List<SelectableValue> findAllByAttributeDefIdIn(List<UUID> defIds) {
 
-    if (defIds == null || defIds.isEmpty()) {
+    log.debug("의상 속성 정의 id 리스트로 속성 값 조회 시작: defIdsSize = {}", defIds.size());
+
+    if (defIds.isEmpty()) {
+      log.debug("defIds가 비어있습니다. return = {}", List.of());
       return List.of();
     }
 
-    return selectableValueRepository.findAllByAttributeDefIdIn(defIds);
+    List<SelectableValue> response = selectableValueRepository.findAllByAttributeDefIdIn(defIds);
+
+    log.debug("의상 속성 정의 id 리스트로 속성 값 조회 완료: valuesSize = {}", response.size());
+    return response;
   }
 
   public List<SelectableValue> updateWhenNameSame(UUID defId, List<UUID> valueIdsForDelete,
       List<String> newValues) {
 
-    log.debug("의상 속성 명 수정(정의 명 수정 X) 시작: defId = {}, newValues = {}", defId, newValues);
+    log.debug("의상 속성 명 수정(정의 명 수정 X) 시작: defId = {}, newValuesSize = {}", defId, newValues.size());
 
     // id 검사
     validateDefId(defId);
@@ -82,17 +92,15 @@ public class SelectableValueService {
         .map(value -> SelectableValue.create(defId, value))
         .toList();
 
-    log.debug("의상 속성 명 수정(정의 명 수정 X) 완료: defId = {}, values = {}", defId,
-        selectableValues.stream()
-            .map(SelectableValue::getItem)
-            .toList());
-    selectableValueRepository.saveAll(selectableValues);
-    return selectableValueRepository.findAllByAttributeDefId(defId);
+    List<SelectableValue> response = selectableValueRepository.saveAll(selectableValues);
+
+    log.debug("의상 속성 명 수정(정의 명 수정 X) 완료: valuesSize = {}", response.size());
+    return response;
   }
 
   public List<SelectableValue> updateWhenNameChanged(UUID defId, List<String> newValues) {
 
-    log.debug("의상 속성 명 수정(정의 명 수정 O) 시작: defId = {}, newValues = {}", defId, newValues);
+    log.debug("의상 속성 명 수정(정의 명 수정 O) 시작: defId = {}, newValuesSize = {}", defId, newValues.size());
 
     // id 검사
     validateDefId(defId);
@@ -105,18 +113,23 @@ public class SelectableValueService {
         .map(value -> SelectableValue.create(defId, value))
         .toList();
 
-    log.debug("의상 속성 명 수정(정의 명 수정 O)  완료: defId = {}, values = {}", defId,
-        selectableValues.stream()
-            .map(SelectableValue::getItem)
-            .toList());
-    return selectableValueRepository.saveAll(selectableValues);
+    List<SelectableValue> response = selectableValueRepository.saveAll(selectableValues);
+
+    log.debug("의상 속성 명 수정(정의 명 수정 O) 완료: valuesSize = {}", response.size());
+    return response;
   }
 
   // 속성 정의 명 리스트로 삭제
   public void deleteByIdIn(List<UUID> valueIds) {
-    log.debug("의상 속성 값 삭제: valueIds = {}", valueIds);
+    log.debug("의상 속성 값 삭제 시작: valueIdsSize = {}", valueIds.size());
 
-    selectableValueRepository.deleteByIdIn(valueIds);
+    if (!valueIds.isEmpty()) {
+      selectableValueRepository.deleteByIdIn(valueIds);
+      log.debug("의상 속성 값 삭제 완료");
+    } else {
+      log.debug("의상 속성 값 id 리스트가 비어있습니다.");
+    }
+
   }
 
   // defId 유효성 검사

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesAttributeDefRepositoryTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesAttributeDefRepositoryTest.java
@@ -30,7 +30,7 @@ class ClothesAttributeDefRepositoryTest {
   class ExistsByName {
 
     @Test
-    @DisplayName("이름이 존재할 경우")
+    @DisplayName("이름이 존재할 경우 - true 반환")
     void existsByName_true() {
 
       // given
@@ -48,7 +48,7 @@ class ClothesAttributeDefRepositoryTest {
     }
 
     @Test
-    @DisplayName("이름이 존재하지 않을 경우")
+    @DisplayName("이름이 존재하지 않을 경우 - false 반환")
     void existsByName_false() {
 
       // given

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepositoryTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.part4.team09.otboo.module.domain.clothes.repository;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepositoryTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/SelectableValueRepositoryTest.java
@@ -63,7 +63,7 @@ class SelectableValueRepositoryTest {
   class FindAllByAttributeDefIdIn {
 
     @Test
-    @DisplayName("성공")
+    @DisplayName("조회 성공")
     void find_all_by_attribute_def_id_in_success() {
 
       // given
@@ -119,17 +119,6 @@ class SelectableValueRepositoryTest {
 
       // then
       assertTrue(result.isEmpty());
-    }
-
-    @Test
-    @DisplayName("잘못된 id")
-    void deleteAllByAttributeDefId_withInvalidId() {
-
-      // given
-      UUID invalidId = UUID.randomUUID();
-
-      // when, then
-      assertDoesNotThrow(() -> selectableValueRepository.deleteAllByAttributeDefId(invalidId));
     }
   }
 

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSLTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSLTest.java
@@ -13,8 +13,6 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSLTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSLTest.java
@@ -1,6 +1,5 @@
 package com.part4.team09.otboo.module.domain.clothes.repository.custom;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.part4.team09.otboo.config.QueryDslConfig;
@@ -11,7 +10,6 @@ import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
 import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
 import com.part4.team09.otboo.module.domain.clothes.repository.SelectableValueRepository;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,8 +27,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class ClothesAttributeDefRepositoryQueryDSLTest {
 
-  private static final Logger log = LoggerFactory.getLogger(
-      ClothesAttributeDefRepositoryQueryDSLTest.class);
   @Autowired
   private ClothesAttributeDefRepositoryQueryDSL queryDSL;
 

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSLTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/repository/custom/ClothesAttributeDefRepositoryQueryDSLTest.java
@@ -13,6 +13,7 @@ import com.part4.team09.otboo.module.domain.clothes.repository.SelectableValueRe
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,7 @@ class ClothesAttributeDefRepositoryQueryDSLTest {
   private SelectableValueRepository valueRepository;
 
   @Test
+  @DisplayName("키워드를 포함하는 의상 속성 정의 명과 속성 값 찾기")
   void find_def_ids_by_keyword() {
     // given
     ClothesAttributeDef def1 = defRepository.save(ClothesAttributeDef.create("사이즈"));
@@ -57,13 +59,14 @@ class ClothesAttributeDefRepositoryQueryDSLTest {
   }
 
   @Test
+  @DisplayName("커서 기반 페이지네이션")
   void find_by_cursor() {
     // given
     ClothesAttributeDef def1 = defRepository.save(ClothesAttributeDef.create("A"));
     ClothesAttributeDef def2 = defRepository.save(ClothesAttributeDef.create("B"));
     ClothesAttributeDef def3 = defRepository.save(ClothesAttributeDef.create("C"));
 
-    Set<UUID> ids = Set.of(def1.getId(), def2.getId(), def3.getId());
+    List<UUID> ids = List.of(def1.getId(), def2.getId(), def3.getId());
     ClothesAttributeDefFindRequest request = new ClothesAttributeDefFindRequest(
         def1.getName(), def1.getId(), 2, "name", SortDirection.ASCENDING, null
     );

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefServiceTest.java
@@ -16,10 +16,8 @@ import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDe
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefNotFoundException;
 import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
 import com.part4.team09.otboo.module.domain.clothes.repository.custom.ClothesAttributeDefRepositoryQueryDSL;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeDefServiceTest.java
@@ -67,7 +67,7 @@ class ClothesAttributeDefServiceTest {
     }
 
     @Test
-    @DisplayName("이름 중복")
+    @DisplayName("이름이 중복일 경우 예외 처리")
     void create_duplicate_name() {
 
       // given
@@ -82,11 +82,11 @@ class ClothesAttributeDefServiceTest {
   }
 
   @Nested
-  @DisplayName("의상 속성 정의 찾기")
+  @DisplayName("의상 속성 정의 조회")
   class FindById {
 
     @Test
-    @DisplayName("찾기 성공")
+    @DisplayName("조회 성공")
     void find_by_id_success() {
 
       // given
@@ -105,7 +105,7 @@ class ClothesAttributeDefServiceTest {
     }
 
     @Test
-    @DisplayName("찾기 실패 - 잘못된 id")
+    @DisplayName("defId가 존재하지 않을 경우 예외 처리")
     void find_by_id_not_found_id() {
 
       // given
@@ -120,11 +120,11 @@ class ClothesAttributeDefServiceTest {
   }
 
   @Nested
-  @DisplayName("키워드로 속성 정의 찾기")
+  @DisplayName("키워드로 속성 정의 및 속성 값의 def id 조회")
   class FindIdsByKeyword {
 
     @Test
-    @DisplayName("키워드로 찾기 성공")
+    @DisplayName("키워드가 있을 경우의 조회 성공")
     void find_ids_by_keyword_success() {
 
       // given
@@ -143,7 +143,7 @@ class ClothesAttributeDefServiceTest {
     }
 
     @Test
-    @DisplayName("키워드가 없음")
+    @DisplayName("키워드가 없는 경우의 조회 성공")
     void find_ids_by_keyword_no_keyword() {
 
       // given
@@ -167,11 +167,11 @@ class ClothesAttributeDefServiceTest {
   class FindByCursor {
 
     @Test
-    @DisplayName("찾기 성공")
+    @DisplayName("defIds가 있는 경우 조회 성공")
     void find_by_cursor_success() {
 
       // given
-      Set<UUID> defIds = new HashSet<>(List.of(UUID.randomUUID()));
+      List<UUID> defIds = List.of(UUID.randomUUID());
       ClothesAttributeDef def = ClothesAttributeDef.create("사이즈");
       ClothesAttributeDefFindRequest request = new ClothesAttributeDefFindRequest(null, null, 10,
           "name", SortDirection.ASCENDING, "사이즈");
@@ -188,11 +188,11 @@ class ClothesAttributeDefServiceTest {
     }
 
     @Test
-    @DisplayName("defIds가 없음")
+    @DisplayName("defIds가 없는 경우 조회 성공")
     void find_by_cursor_no_def_ids() {
 
       // given
-      Set<UUID> defIds = Set.of();
+      List<UUID> defIds = List.of();
       ClothesAttributeDefFindRequest request = new ClothesAttributeDefFindRequest(null, null, 10,
           "name", SortDirection.ASCENDING, "사이즈");
       List<ClothesAttributeDef> defs = List.of();
@@ -232,7 +232,7 @@ class ClothesAttributeDefServiceTest {
     }
 
     @Test
-    @DisplayName("속성 정의 id가 존재하지 않음")
+    @DisplayName("defId가 존재하지 않을 경우 예외 처리")
     void update_not_found_def_id() {
 
       // given
@@ -256,12 +256,32 @@ class ClothesAttributeDefServiceTest {
 
       // given
       UUID defId = UUID.randomUUID();
+      ClothesAttributeDef def = ClothesAttributeDef.create("사이즈");
+
+      given(clothesAttributeDefRepository.findById(defId)).willReturn(Optional.of(def));
 
       // when
       clothesAttributeDefService.delete(defId);
 
       // then
+      then(clothesAttributeDefRepository).should().findById(defId);
       then(clothesAttributeDefRepository).should().deleteById(defId);
+    }
+
+    @Test
+    @DisplayName("defId가 존재하지 않을 경우 예외 처리")
+    void delete_fail_not_found_def() {
+
+      // given
+      UUID defId = UUID.randomUUID();
+
+      given(clothesAttributeDefRepository.findById(defId)).willReturn(Optional.empty());
+
+      // when, then
+      assertThrows(ClothesAttributeDefNotFoundException.class, () -> clothesAttributeDefService.delete(defId));
+
+      then(clothesAttributeDefRepository).should().findById(defId);
+      then(clothesAttributeDefRepository).should(times(0)).deleteById(defId);
     }
   }
 }

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoServiceTest.java
@@ -2,26 +2,19 @@ package com.part4.team09.otboo.module.domain.clothes.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import com.part4.team09.otboo.module.common.entity.BaseEntity;
-import com.part4.team09.otboo.module.common.enums.SortDirection;
 import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDefDto;
 import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefCreateRequest;
-import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefFindRequest;
 import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefUpdateRequest;
-import com.part4.team09.otboo.module.domain.clothes.dto.response.ClothesAttributeDefDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
 import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
 import com.part4.team09.otboo.module.domain.clothes.mapper.ClothesAttributeDefDtoCursorResponseMapper;
 import com.part4.team09.otboo.module.domain.clothes.mapper.ClothesAttributeDefMapper;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesAttributeInfoServiceTest.java
@@ -2,18 +2,26 @@ package com.part4.team09.otboo.module.domain.clothes.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import com.part4.team09.otboo.module.common.entity.BaseEntity;
+import com.part4.team09.otboo.module.common.enums.SortDirection;
 import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDefDto;
 import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefCreateRequest;
+import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefFindRequest;
 import com.part4.team09.otboo.module.domain.clothes.dto.request.ClothesAttributeDefUpdateRequest;
+import com.part4.team09.otboo.module.domain.clothes.dto.response.ClothesAttributeDefDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
 import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
+import com.part4.team09.otboo.module.domain.clothes.mapper.ClothesAttributeDefDtoCursorResponseMapper;
 import com.part4.team09.otboo.module.domain.clothes.mapper.ClothesAttributeDefMapper;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -42,6 +50,9 @@ class ClothesAttributeInfoServiceTest {
 
   @Mock
   private ClothesAttributeDefMapper clothesAttributeDefMapper;
+
+  @Mock
+  private ClothesAttributeDefDtoCursorResponseMapper clothesAttributeDefDtoCursorResponseMapper;
 
   @Nested
   @DisplayName("의상 속성 생성")
@@ -87,12 +98,6 @@ class ClothesAttributeInfoServiceTest {
           selectableValues.stream().map(SelectableValue::getItem)
               .toList());
     }
-  }
-
-  @Nested
-  @DisplayName("의상 속성 찾기")
-  class FindByCursor {
-
   }
 
   @Nested

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueServiceTest.java
@@ -184,9 +184,6 @@ class SelectableValueServiceTest {
           .filter(value -> !oldValueSet.contains(value))
           .map(value -> SelectableValue.create(defId, value))
           .toList();
-      List<SelectableValue> findSelectableValues = newValues.stream()
-          .map(value -> SelectableValue.create(defId, value))
-          .toList();
 
       given(clothesAttributeDefRepository.existsById(defId)).willReturn(true);
       given(selectableValueRepository.findAllByAttributeDefId(defId)).willReturn(oldSelectableValues);

--- a/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/clothes/service/SelectableValueServiceTest.java
@@ -66,7 +66,7 @@ class SelectableValueServiceTest {
     }
 
     @Test
-    @DisplayName("잘못된 속성 정의 id")
+    @DisplayName("defId가 존재하지 않을 경우 예외 처리")
     void create_invalid_id() {
 
       // given
@@ -81,11 +81,11 @@ class SelectableValueServiceTest {
   }
 
   @Nested
-  @DisplayName("def id로 속성 값 찾기")
+  @DisplayName("defId로 속성 값 조회")
   class FindAllByAttributeDefId {
 
     @Test
-    @DisplayName("속성 값 def id로 찾기 성공")
+    @DisplayName("속성 값 defId로 조회 성공")
     void find_all_by_attribute_def_id_success() {
 
       // given
@@ -108,7 +108,7 @@ class SelectableValueServiceTest {
     }
 
     @Test
-    @DisplayName("속성 값 def id로 찾기 실패 - def가 없음")
+    @DisplayName("defId가 존재하지 않을 경우 예외 처리")
     void find_all_by_attribute_def_id_not_found_def() {
 
       // given
@@ -124,11 +124,11 @@ class SelectableValueServiceTest {
   }
 
   @Nested
-  @DisplayName("def id 리스트로 속성 값 찾기")
+  @DisplayName("defId 리스트로 속성 값 조회")
   class findAllByAttributeDefIdIn {
 
     @Test
-    @DisplayName("찾기 성공")
+    @DisplayName("defId 리스트가 존재하는 경우 조회 성공")
     void find_all_by_attribute_def_id_in_success() {
 
       // given
@@ -147,7 +147,7 @@ class SelectableValueServiceTest {
     }
 
     @Test
-    @DisplayName("def id 리스트가 없음")
+    @DisplayName("defId 리스트가 존재하지 않는 경우 조회 성공")
     void find_all_by_attribute_def_id_in_no_def_ids() {
 
       // given
@@ -165,11 +165,11 @@ class SelectableValueServiceTest {
   }
 
   @Nested
-  @DisplayName("속성 값 수정")
-  class Update {
+  @DisplayName("정의 명이 수정되지 않았을 경우의 속성 값 수정")
+  class UpdateWhenNameSame {
 
     @Test
-    @DisplayName("정의 명 수정 X - 성공")
+    @DisplayName("정의 명이 수정되지 않았을 경우의 속성 값 수정 성공")
     void update_when_name_same_success() {
       // given
       UUID defId = UUID.randomUUID();
@@ -191,22 +191,20 @@ class SelectableValueServiceTest {
       given(clothesAttributeDefRepository.existsById(defId)).willReturn(true);
       given(selectableValueRepository.findAllByAttributeDefId(defId)).willReturn(oldSelectableValues);
       given(selectableValueRepository.saveAll(anyList())).willReturn(selectableValues);
-      given(selectableValueRepository.findAllByAttributeDefId(defId)).willReturn(findSelectableValues);
 
       // when
       List<SelectableValue> results = selectableValueService.updateWhenNameSame(defId, valueIdsForDelete, newValues);
 
       // then
       assertNotNull(results);
-      assertEquals(results, findSelectableValues);
       then(clothesAttributeDefRepository).should().existsById(defId);
       then(selectableValueRepository).should().deleteByIdIn(valueIdsForDelete);
-      then(selectableValueRepository).should(times(2)).findAllByAttributeDefId(defId);
+      then(selectableValueRepository).should().findAllByAttributeDefId(defId);
       then(selectableValueRepository).should().saveAll(anyList());
     }
 
     @Test
-    @DisplayName("정의 명 수정 X - 잘못된 def id")
+    @DisplayName("defId가 존재하지 않을 경우 예외 처리")
     void update_when_name_same_not_found_def() {
       //given
       UUID defId = UUID.randomUUID();
@@ -218,8 +216,14 @@ class SelectableValueServiceTest {
           () -> selectableValueService.updateWhenNameSame(defId, List.of(), List.of()));
     }
 
+  }
+
+  @Nested
+  @DisplayName("정의 명이 수정었을 경우의 속성 값 수정")
+  class UpdateWhenNameChanged {
+
     @Test
-    @DisplayName("정의 명 수정 O - 성공")
+    @DisplayName("정의 명이 수정었을 경우의 속성 값 수정 성공")
     void update_when_name_changed_success() {
 
       // given
@@ -244,7 +248,7 @@ class SelectableValueServiceTest {
     }
 
     @Test
-    @DisplayName("정의 명 수정 X - 잘못된 def id")
+    @DisplayName("defId가 존재하지 않을 경우 예외 처리")
     void update_when_name_changed_not_found_def() {
       //given
       UUID defId = UUID.randomUUID();
@@ -273,6 +277,20 @@ class SelectableValueServiceTest {
 
       // then
       then(selectableValueRepository).should().deleteByIdIn(valueIds);
+    }
+
+    @Test
+    @DisplayName("valueIds가 비어있을 경우 삭제 하지 않믐")
+    void delete_by_id_in_no_value_ids() {
+
+      // given
+      List<UUID> valueIds = List.of();
+
+      // when
+      selectableValueService.deleteByIdIn(valueIds);
+
+      // then
+      then(selectableValueRepository).should(times(0)).deleteByIdIn(valueIds);
     }
   }
 }


### PR DESCRIPTION
## Issue Number
#54 

## 요약(Summary)
- 의상 속성 정의 관련 코드의 로깅, 예외처리, 테스트를 수정했습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)
## 공유사항 to 리뷰어
### 의상 속성 정의 등록 3개
![image](https://github.com/user-attachments/assets/3810a70d-947b-4d16-a32a-c1867abc752a)
![image](https://github.com/user-attachments/assets/cb8f5255-71da-4657-99c0-11cd29d4e254)
![image](https://github.com/user-attachments/assets/302dc930-d4f5-4909-a5c8-0ba8c94b5657)

### 조회
#### 1. 키워드 "레"로 조회
- 정의 명 또는 속성 값에 "레"가 들어가 있는 것들을 조회
![image](https://github.com/user-attachments/assets/e5d188bd-753d-47ac-ab3e-e9ef37fda831)

#### 2, 키워드 "레" + 리미트를 1로 조회
![image](https://github.com/user-attachments/assets/1df982a7-a0d2-4999-bf36-d91f8e036c04)

#### 3, 전체 조회
![image](https://github.com/user-attachments/assets/c029cae4-6047-4410-b496-7dd0729f03cf)

#### 4. 정의 명 내림차순 정렬
![image](https://github.com/user-attachments/assets/46050696-b644-4f64-94c3-a862738086d8)

#### 5. nextCursor, nextIdAfer 사용("둘레", 둘레 정의 id)
- 둘레 이후의 속성 정의 조회
![image](https://github.com/user-attachments/assets/4e131250-f09a-4243-b56d-2771a1c9642d)

#### 6. 분류를 생성일로 조회
![image](https://github.com/user-attachments/assets/8d4e65bf-3266-46c9-be69-9ba086a7a961)

#### 7. 양수가 아닌 limit 입력
![image](https://github.com/user-attachments/assets/1ff765f0-e035-42a2-8578-76565a8b7485)

#### 8. 유효하지 않은 분류 입력
![image](https://github.com/user-attachments/assets/314982b2-fdf1-451b-9491-eed2045a93cc)

#### postman 파일
[의상 속성 정의 조회.postman_collection.json](https://github.com/user-attachments/files/21013876/postman_collection.json)

## Close Issue

close #54