### PR TITLE
Refactor: 팔로우 서비스 일부, 페이징 수정 

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/contoller/FollowController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/contoller/FollowController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.HttpStatus;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Slf4j
@@ -41,7 +42,7 @@ public class FollowController {
             @RequestParam(required = false) String nameLike
             ){
 
-        FollowListResponse response = followService.getFollowings(followerId, idAfter, limit, nameLike);
+        FollowListResponse response = followService.getFollowings(followerId, cursor, idAfter, limit, nameLike);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -58,7 +59,7 @@ public class FollowController {
             @RequestParam(required = false) String nameLike
     ){
 
-        FollowListResponse response = followService.getFollowers(followeeId, idAfter, limit, nameLike);
+        FollowListResponse response = followService.getFollowers(followeeId, cursor, idAfter, limit, nameLike);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/dto/FollowListRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/dto/FollowListRequest.java
@@ -1,0 +1,14 @@
+package com.part4.team09.otboo.module.domain.follow.dto;
+
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record FollowListRequest(
+        UUID userId,
+        LocalDateTime cursor,
+        UUID idAFter,
+        int limit,
+        String nameLike
+) {
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/dto/FollowListResponse.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/dto/FollowListResponse.java
@@ -1,5 +1,7 @@
 package com.part4.team09.otboo.module.domain.follow.dto;
 
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -13,8 +15,5 @@ public record FollowListResponse(
         SortDirection sortDirection
 
 ) {
-    public enum SortDirection {
-        ASCENDING,
-        DESCENDING
-    }
+
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -34,6 +35,7 @@ public class FollowService {
   private final FollowMapper followMapper;
 
   // 팔로우 등록
+  @Transactional
   public FollowDto create(UUID followeeId, UUID followerId) {
     // 예외처리 1. existsById시 유저가 존재 x    2. 자기자신은 팔로우 불가
     if (!userRepository.existsById(followeeId)) {
@@ -57,6 +59,7 @@ public class FollowService {
 
 
   // 팔로잉 목록 조회
+  @Transactional(readOnly = true)
   public FollowListResponse getFollowings(UUID followerId, UUID idAfter, int limit,
     String nameLike) {
 
@@ -119,6 +122,7 @@ public class FollowService {
 
 
   // 팔로워 목록 조회
+  @Transactional(readOnly = true)
   public FollowListResponse getFollowers(UUID followeeId, UUID idAfter, int limit,
     String nameLike) {
 
@@ -189,6 +193,7 @@ public class FollowService {
   }
 
   // 팔로우 삭제
+  @Transactional
   public void deleteFollow(UUID followId) {
     // 해당 팔로우가 애초에 존재하지 않아서 취소할 수 없음 예외
     if (!followRepository.existsById(followId)) {

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
@@ -1,5 +1,6 @@
 package com.part4.team09.otboo.module.domain.follow.service;
 
+import com.part4.team09.otboo.module.common.enums.SortDirection;
 import com.part4.team09.otboo.module.domain.follow.dto.FollowDto;
 import com.part4.team09.otboo.module.domain.follow.dto.FollowListResponse;
 import com.part4.team09.otboo.module.domain.follow.entity.Follow;
@@ -113,7 +114,7 @@ public class FollowService {
 
     // 팔로잉, 팔로워 목록 조회에서는 클라이언트가 정렬 조건과 순서를 지정하지 않기 때문에 개발단에서 지정한 걸로 명시해서 반환 (id 기준, DESCENDING)
     return new FollowListResponse(pagedFollowDtoList, nextCursor, nextIdAfter, hasNext, totalCount,
-      "createdAt, id", FollowListResponse.SortDirection.DESCENDING);
+      "createdAt, id", SortDirection.DESCENDING);
   }
 
 
@@ -173,7 +174,7 @@ public class FollowService {
     log.info("팔로워 목록 조회 끝");
 
     return new FollowListResponse(pagedFollowDtoList, nextCursor, nextIdAfter, hasNext, totalCount,
-      "createdAt, id", FollowListResponse.SortDirection.DESCENDING);
+      "createdAt, id", SortDirection.DESCENDING);
   }
 
   // cursor 인코딩 로직

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
@@ -2,6 +2,7 @@ package com.part4.team09.otboo.module.domain.follow.service;
 
 import com.part4.team09.otboo.module.common.enums.SortDirection;
 import com.part4.team09.otboo.module.domain.follow.dto.FollowDto;
+import com.part4.team09.otboo.module.domain.follow.dto.FollowListRequest;
 import com.part4.team09.otboo.module.domain.follow.dto.FollowListResponse;
 import com.part4.team09.otboo.module.domain.follow.entity.Follow;
 import com.part4.team09.otboo.module.domain.follow.exception.FollowNotFoundException;
@@ -13,6 +14,7 @@ import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
@@ -60,37 +62,30 @@ public class FollowService {
 
   // 팔로잉 목록 조회
   @Transactional(readOnly = true)
-  public FollowListResponse getFollowings(UUID followerId, UUID idAfter, int limit,
+  public FollowListResponse getFollowings(UUID followerId, String cursor, UUID idAfter, int limit,
     String nameLike) {
 
-    log.info("팔로잉 목록 조회 시작: followerId={}, idAfter={}, limit={}, nameLike={}", followerId, idAfter,
-      limit, nameLike);
+    log.info("팔로잉 목록 조회 시작: followerId={}, idAfter={}, limit={}, nameLike={}", followerId, idAfter, limit, nameLike);
 
     // limit은 0보다 커야 한다는 예외처리
     if (limit <= 0) {
       throw new NegativeLimitNotAllowed(limit);
     }
 
-    // JPQL 쿼리문에 페이징할 사이즈를 전달하기 위한 pageable 객체
-    Pageable pageable = PageRequest.of(0, limit + 1);
-
-    List<Follow> pagedFollowList;
-    LocalDateTime createdAtAfter = null;
-    int totalCount;
-
-    // createdAt을 기준으로 정렬하기 위해 현재 idAfter로 가장 마지막 값의 createdAt을 가져오기
-    if (idAfter != null) {
-      createdAtAfter = followRepository.findById(idAfter).orElseThrow().getCreatedAt();
-    }
+    // cursor을 LocalDateTime으로 디코딩
+    LocalDateTime decodedCursor = decodeCursor(cursor);
 
     // 팔로잉 목록 조회 시작
+    FollowListRequest request = new FollowListRequest(followerId, decodedCursor, idAfter, limit+1, nameLike);
+    List<Follow> pagedFollowList;
+    int totalCount;
+
     totalCount = followRepositoryQueryDSL.countFollowings(followerId, nameLike);
-    pagedFollowList = followRepositoryQueryDSL.getFollowings(followerId, idAfter, createdAtAfter,
-      nameLike, pageable);
+    pagedFollowList = followRepositoryQueryDSL.getFollowings(request);
 
     log.debug("전체 팔로잉 카운트: {}", totalCount);
 
-    // (limit+1)개만큼 가져온 이유는 hasNext를 계산하기 위함. (limit+1)개를 followList에 저장했기 때문에 사이즈가 limit보다 크다면 hasNext가 true인 것
+    // 쿼리에서 (limit+1)개만큼 가져온 이유는 hasNext를 계산하기 위함. (limit+1)개를 followList에 저장했기 때문에 사이즈가 limit보다 크다면 hasNext가 true인 것
     // hasNext 판단 후, 진짜 data는 (limit)개만큼 subList로 가져오기
     boolean hasNext = pagedFollowList.size() > limit;
     if (hasNext) {
@@ -103,16 +98,16 @@ public class FollowService {
       .collect(Collectors.toList());
 
     // 다음 커서 생성
+    LocalDateTime nextCursorBeforeEncoding = null;
     UUID nextIdAfter = null;
-
     if (hasNext && !pagedFollowList.isEmpty()) { // pagedFollowList NPE 방지하기
+      nextCursorBeforeEncoding = pagedFollowList.get(limit - 1).getCreatedAt();
       nextIdAfter = pagedFollowList.get(limit - 1).getId();
     }
 
-    String nextCursor = encodeIdAfterToCursor(nextIdAfter); // cursor는 idAfter을 Base64로 인코딩해서 만듭니다
+    // cursor을 String으로 인코딩
+    String nextCursor = encodeCursor(nextCursorBeforeEncoding);
 
-    log.debug("hasNext: {}, 실제 반환 개수: {}", hasNext, pagedFollowList.size());
-    log.debug("nextCursor: {}", nextCursor);
     log.info("팔로잉 목록 조회 끝");
 
     // 팔로잉, 팔로워 목록 조회에서는 클라이언트가 정렬 조건과 순서를 지정하지 않기 때문에 개발단에서 지정한 걸로 명시해서 반환 (id 기준, DESCENDING)
@@ -123,73 +118,66 @@ public class FollowService {
 
   // 팔로워 목록 조회
   @Transactional(readOnly = true)
-  public FollowListResponse getFollowers(UUID followeeId, UUID idAfter, int limit,
-    String nameLike) {
+  public FollowListResponse getFollowers(UUID followeeId, String cursor, UUID idAfter, int limit, String nameLike) {
 
-    log.info("팔로워 목록 조회 시작: followeeId={}, idAfter={}, limit={}, nameLike={}", followeeId, idAfter,
-      limit, nameLike);
+    log.info("팔로워 목록 조회 시작: followeeId={}, idAfter={}, limit={}, nameLike={}", followeeId, idAfter, limit, nameLike);
 
-    // limit 예외처리
+    // limit은 0보다 커야 한다는 예외처리
     if (limit <= 0) {
       throw new NegativeLimitNotAllowed(limit);
     }
 
-    // JPQL 쿼리문에 페이징할 사이즈를 전달하기 위한 pageable 객체
-    Pageable pageable = PageRequest.of(0, limit + 1);
+    // cursor을 LocalDateTime으로 디코딩
+    LocalDateTime decodedCursor = decodeCursor(cursor);
 
+    // 팔로잉 목록 조회 시작
+    FollowListRequest request = new FollowListRequest(followeeId, decodedCursor, idAfter, limit+1, nameLike);
     List<Follow> pagedFollowList;
-    LocalDateTime createdAtAfter = null;
     int totalCount;
 
-    // createdAt을 기준으로 정렬하기 위해 현재 idAfter로 가장 마지막 값의 createdAt을 가져오기
-    if (idAfter != null) {
-      createdAtAfter = followRepository.findById(idAfter).orElseThrow().getCreatedAt();
-    }
-
-    // 팔로워 목록 조회 시작
     totalCount = followRepositoryQueryDSL.countFollowers(followeeId, nameLike);
-    pagedFollowList = followRepositoryQueryDSL.getFollowers(followeeId, idAfter, createdAtAfter,
-      nameLike, pageable);
+    pagedFollowList = followRepositoryQueryDSL.getFollowers(request);
 
     log.debug("전체 팔로워 카운트: {}", totalCount);
 
+    // 쿼리에서 (limit+1)개만큼 가져온 이유는 hasNext를 계산하기 위함. (limit+1)개를 followList에 저장했기 때문에 사이즈가 limit보다 크다면 hasNext가 true인 것
     // hasNext 판단 후, 진짜 data는 (limit)개만큼 subList로 가져오기
     boolean hasNext = pagedFollowList.size() > limit;
     if (hasNext) {
       pagedFollowList = pagedFollowList.subList(0, limit);
     }
 
-    // 필로워 목록 데이터 Dto 변환
+    // 필로잉 목록 데이터 Dto 변환
     List<FollowDto> pagedFollowDtoList = pagedFollowList.stream()
-      .map(followMapper::toDto)
-      .collect(Collectors.toList());
+            .map(followMapper::toDto)
+            .collect(Collectors.toList());
 
     // 다음 커서 생성
+    LocalDateTime nextCursorBeforeEncoding = null;
     UUID nextIdAfter = null;
-
     if (hasNext && !pagedFollowList.isEmpty()) { // pagedFollowList NPE 방지하기
+      nextCursorBeforeEncoding = pagedFollowList.get(limit - 1).getCreatedAt();
       nextIdAfter = pagedFollowList.get(limit - 1).getId();
     }
 
-    String nextCursor = encodeIdAfterToCursor(nextIdAfter); // cursor는 idAfter을 Base64로 인코딩해서 만듭니다
+    // cursor을 String으로 인코딩
+    String nextCursor = encodeCursor(nextCursorBeforeEncoding);
 
-    log.debug("hasNext: {}, 실제 반환 개수: {}", hasNext, pagedFollowList.size());
-    log.debug("nextCursor: {}", nextCursor);
     log.info("팔로워 목록 조회 끝");
 
+    // 팔로잉, 팔로워 목록 조회에서는 클라이언트가 정렬 조건과 순서를 지정하지 않기 때문에 개발단에서 지정한 걸로 명시해서 반환 (id 기준, DESCENDING)
     return new FollowListResponse(pagedFollowDtoList, nextCursor, nextIdAfter, hasNext, totalCount,
-      "createdAt, id", SortDirection.DESCENDING);
+            "createdAt, id", SortDirection.DESCENDING);
   }
 
-  // cursor 인코딩 로직
-  private String encodeIdAfterToCursor(UUID idAfter) {
-    if (idAfter == null) {
-      return null;
-    }
-    String uuidStr = idAfter.toString();
-    byte[] bytes = uuidStr.getBytes(StandardCharsets.UTF_8);
-    String cursor = Base64.getEncoder().encodeToString(bytes);
-    return cursor;
+  // cursor 인코딩 로직 (LocalDateTime -> String)
+  private String encodeCursor(LocalDateTime cursor) {
+    return cursor == null ? null : cursor.toString();
+  }
+
+  // cursor 디코딩 로직 (String -> LocalDateTime)
+  private LocalDateTime decodeCursor(String cursor){
+    return cursor == null || cursor.isEmpty() ? null : LocalDateTime.parse(cursor);
   }
 
   // 팔로우 삭제


### PR DESCRIPTION
## Issue Number
55

## 요약(Summary)
- 팔로우 서비스 일부와 페이징 수정했습니다.
- [x] Dto 내부 Enum 삭제하고 common Enum 으로 교체
- [x] Transactional 어노테이션 추가
- [x] 팔로잉/팔로워 목록 조회 페이징 수정


## PR 유형
refactor

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)
- 서비스, 포스트맨 테스트 진행했습니다.

## 공유사항 to 리뷰어
- 저번에 cursor와 idAfter를 같이 받고, 반환하는 이유를 명확히 이해하지 못했어서 관련 내용 pr 템플릿에 첨부한 후에 서비스 파라미터에서 cursor 값을 없애고 구현했었는데, cursor는 정렬 기준인 createdAt의 마지막 값이고 idAfter는 중복값을 거르기 위한 파라미터인 걸 확실히 파악한 후에 리팩토링하게 되었습니다.
- cursor가 string으로 들어오면 서비스 내부에서 로컬시간대로 파싱합니다.
- 이 파싱된 cursor을 쿼리에 전달해준 후, 반환된 팔로잉/팔로워 리스트의 마지막 값의 createdAt 값을 get해서 nextCursor을 얻습니다. 그 후 이걸 다시 string으로 인코딩해서 반환합니다!


## Close Issue

close #55