### PR TITLE
Refactor: 프로필 위치 업데이트 부분 수정 및 프로필 이미지(파일) 삭제

### DIFF
--- a/src/main/java/com/part4/team09/otboo/config/AppConfig.java
+++ b/src/main/java/com/part4/team09/otboo/config/AppConfig.java
@@ -2,8 +2,10 @@ package com.part4.team09.otboo.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
 @Configuration
+@EnableRetry
 @EnableJpaAuditing
 public class AppConfig {
 

--- a/src/main/java/com/part4/team09/otboo/config/AsyncConfig.java
+++ b/src/main/java/com/part4/team09/otboo/config/AsyncConfig.java
@@ -1,0 +1,10 @@
+package com.part4.team09.otboo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+  
+}

--- a/src/main/java/com/part4/team09/otboo/config/LocalWebMvcConfig.java
+++ b/src/main/java/com/part4/team09/otboo/config/LocalWebMvcConfig.java
@@ -1,6 +1,7 @@
 package com.part4.team09.otboo.config;
 
 import java.nio.file.Paths;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -10,12 +11,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class LocalWebMvcConfig implements WebMvcConfigurer {
 
+  @Value("${otboo.resource.path}")
+  private String resourcePath;
+
   // local 리소스 접근
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
     String absolutePath = Paths.get(System.getProperty("user.dir"), "fileStorage").toAbsolutePath()
       .toUri().toString();
-    registry.addResourceHandler("/files/**")
+    registry.addResourceHandler("/" + resourcePath + "/**")
       .addResourceLocations(absolutePath)
       .setCachePeriod(3600);
   }

--- a/src/main/java/com/part4/team09/otboo/module/domain/file/service/FileStorage.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/file/service/FileStorage.java
@@ -5,7 +5,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface FileStorage {
 
-  // retry 처리: 실패 시 알림 처리
   String upload(MultipartFile file, FileDomain domain);
 
   boolean remove(String path);

--- a/src/main/java/com/part4/team09/otboo/module/domain/file/service/LocalFileStorage.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/file/service/LocalFileStorage.java
@@ -106,7 +106,7 @@ public class LocalFileStorage implements FileStorage {
   }
 
   // 삭제를 위한 파일 경로 추출
-  private Path toStoragePath(String fileUrl) {
+  Path toStoragePath(String fileUrl) {
 
     String resourcePrefix = resourcePath + "/";
     int index = fileUrl.indexOf(resourcePrefix);

--- a/src/main/java/com/part4/team09/otboo/module/domain/location/exception/LocationNotFoundException.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/location/exception/LocationNotFoundException.java
@@ -12,12 +12,4 @@ public class LocationNotFoundException extends LocationException {
     exception.addDetail("id", id);
     return exception;
   }
-
-  public static LocationNotFoundException withLatitudeAndLongitude(double latitude,
-    double longitude) {
-    LocationNotFoundException exception = new LocationNotFoundException();
-    exception.addDetail("latitude", latitude);
-    exception.addDetail("longitude", longitude);
-    return exception;
-  }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/location/repository/DongRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/location/repository/DongRepository.java
@@ -4,21 +4,9 @@ import com.part4.team09.otboo.module.domain.location.entity.Dong;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface DongRepository extends JpaRepository<Dong, UUID> {
 
   Optional<Dong> findByDongName(String dongName);
-
-  @Query(""
-    + "SELECT d.id "
-    + "FROM Dong d "
-    + "WHERE d.latitude = :latitude AND d.longitude = :longitude"
-    + "")
-  Optional<UUID> findIdByLatitudeAndLongitude(
-    @Param("latitude") double latitude,
-    @Param("longitude") double longitude
-  );
 
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/location/repository/LocationRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/location/repository/LocationRepository.java
@@ -1,14 +1,8 @@
 package com.part4.team09.otboo.module.domain.location.repository;
 
 import com.part4.team09.otboo.module.domain.location.entity.Location;
-import java.util.Optional;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface LocationRepository extends JpaRepository<Location, String> {
 
-  @Query("SELECT l.id FROM Location l WHERE l.dongId = :dongId")
-  Optional<String> findIdByDongId(@Param("dongId") UUID dongId);
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/user/event/UserEventListener.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/user/event/UserEventListener.java
@@ -1,0 +1,21 @@
+package com.part4.team09.otboo.module.domain.user.event;
+
+import com.part4.team09.otboo.module.domain.file.service.FileStorage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UserEventListener {
+
+  private final FileStorage fileStorage;
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void removePreviousProfileFile(UserProfileUpdateEvent event) {
+    fileStorage.remove(event.beforeImageUrl());
+  }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/user/event/UserEventListener.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/user/event/UserEventListener.java
@@ -16,6 +16,6 @@ public class UserEventListener {
   @Async
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void removePreviousProfileFile(UserProfileUpdateEvent event) {
-    fileStorage.remove(event.beforeImageUrl());
+    fileStorage.remove(event.previousImageUrl());
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/user/event/UserProfileUpdateEvent.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/user/event/UserProfileUpdateEvent.java
@@ -1,0 +1,7 @@
+package com.part4.team09.otboo.module.domain.user.event;
+
+public record UserProfileUpdateEvent(
+  String beforeImageUrl
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/user/event/UserProfileUpdateEvent.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/user/event/UserProfileUpdateEvent.java
@@ -1,7 +1,7 @@
 package com.part4.team09.otboo.module.domain.user.event;
 
 public record UserProfileUpdateEvent(
-  String beforeImageUrl
+  String previousImageUrl
 ) {
 
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/user/service/UserService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/user/service/UserService.java
@@ -4,7 +4,6 @@ import com.part4.team09.otboo.module.domain.file.FileDomain;
 import com.part4.team09.otboo.module.domain.file.exception.FileUploadFailedException;
 import com.part4.team09.otboo.module.domain.file.service.FileStorage;
 import com.part4.team09.otboo.module.domain.location.dto.response.WeatherAPILocation;
-import com.part4.team09.otboo.module.domain.location.exception.LocationNotFoundException;
 import com.part4.team09.otboo.module.domain.location.repository.DongRepository;
 import com.part4.team09.otboo.module.domain.location.repository.LocationRepository;
 import com.part4.team09.otboo.module.domain.location.service.LocationService;
@@ -21,7 +20,6 @@ import com.part4.team09.otboo.module.domain.user.exception.EmailAlreadyExistsExc
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.mapper.UserMapper;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
-import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import java.util.Optional;
 import java.util.UUID;
@@ -29,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -66,7 +65,7 @@ public class UserService {
   }
 
   // 프로필 조회
-  @Transactional
+  @Transactional(readOnly = true)
   public ProfileDto getProfile(UUID id) {
     User user = findByIdOrThrow(id);
 
@@ -173,10 +172,11 @@ public class UserService {
     }
     double latitude = location.latitude();
     double longitude = location.longitude();
-    UUID dongId = dongRepository.findIdByLatitudeAndLongitude(latitude, longitude)
-      .orElseThrow(() -> LocationNotFoundException.withLatitudeAndLongitude(latitude, longitude));
-    return locationRepository.findIdByDongId(dongId)
-      .orElseThrow(() -> LocationNotFoundException.withNameAndId("dong", dongId));
+    return locationService.getLocationCodeByCoordinates(longitude, latitude);
+//    UUID dongId = dongRepository.findIdByLatitudeAndLongitude(latitude, longitude)
+//      .orElseThrow(() -> LocationNotFoundException.withLatitudeAndLongitude(latitude, longitude));
+//    return locationRepository.findIdByDongId(dongId)
+//      .orElseThrow(() -> LocationNotFoundException.withNameAndId("dong", dongId));
   }
 
   // 업로드 후 url 을 리턴하면 저장, null 인 경우(실패) 이전 값 유지

--- a/src/main/java/com/part4/team09/otboo/module/domain/user/service/UserService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/user/service/UserService.java
@@ -4,8 +4,6 @@ import com.part4.team09.otboo.module.domain.file.FileDomain;
 import com.part4.team09.otboo.module.domain.file.exception.FileUploadFailedException;
 import com.part4.team09.otboo.module.domain.file.service.FileStorage;
 import com.part4.team09.otboo.module.domain.location.dto.response.WeatherAPILocation;
-import com.part4.team09.otboo.module.domain.location.repository.DongRepository;
-import com.part4.team09.otboo.module.domain.location.repository.LocationRepository;
 import com.part4.team09.otboo.module.domain.location.service.LocationService;
 import com.part4.team09.otboo.module.domain.user.dto.ProfileDto;
 import com.part4.team09.otboo.module.domain.user.dto.UserDto;
@@ -40,8 +38,6 @@ public class UserService {
   private final UserMapper userMapper;
   private final LocationService locationService;
   private final FileStorage fileStorage;
-  private final DongRepository dongRepository;
-  private final LocationRepository locationRepository;
 
   @Transactional
   public UserDto createUser(UserCreateRequest request) {
@@ -173,10 +169,6 @@ public class UserService {
     double latitude = location.latitude();
     double longitude = location.longitude();
     return locationService.getLocationCodeByCoordinates(longitude, latitude);
-//    UUID dongId = dongRepository.findIdByLatitudeAndLongitude(latitude, longitude)
-//      .orElseThrow(() -> LocationNotFoundException.withLatitudeAndLongitude(latitude, longitude));
-//    return locationRepository.findIdByDongId(dongId)
-//      .orElseThrow(() -> LocationNotFoundException.withNameAndId("dong", dongId));
   }
 
   // 업로드 후 url 을 리턴하면 저장, null 인 경우(실패) 이전 값 유지

--- a/src/main/java/com/part4/team09/otboo/module/domain/user/service/UserService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/user/service/UserService.java
@@ -112,7 +112,7 @@ public class UserService {
 
     // 위치
     Optional.ofNullable(request.location()).ifPresent(location -> {
-      String locationId = findLocationOrThrow(location);
+      String locationId = getLocationIdByCoordinates(location);
       if (locationId != null && !locationId.equals(user.getLocationId())) {
         user.updateLocationId(locationId);
       }
@@ -176,7 +176,7 @@ public class UserService {
     return userRepository.findById(id).orElseThrow(() -> UserNotFoundException.withId(id));
   }
 
-  private String findLocationOrThrow(LocationUpdateRequest location) {
+  private String getLocationIdByCoordinates(LocationUpdateRequest location) {
     if (location == null) {
       return null;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,8 @@ otboo:
     storage:
       type: ${FILE_STORAGE_TYPE:local}
       path: ${FILE_STORAGE_PATH:${user.dir}/fileStorage}
+  resource:
+    path: files
 
 
 # ?? ?? ??

--- a/src/test/java/com/part4/team09/otboo/module/domain/file/service/LocalFileStorageTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/file/service/LocalFileStorageTest.java
@@ -1,0 +1,109 @@
+package com.part4.team09.otboo.module.domain.file.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.part4.team09.otboo.module.domain.file.FileDomain;
+import com.part4.team09.otboo.module.domain.file.exception.FileUploadFailedException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class LocalFileStorageTest {
+
+  @Mock
+  private MultipartFile multipartFile;
+
+  @InjectMocks
+  private LocalFileStorage localFileStorage;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트용 값 주입
+    ReflectionTestUtils.setField(localFileStorage, "resourcePath", "files");
+    ReflectionTestUtils.setField(localFileStorage, "saveBasePath", Paths.get("test"));
+  }
+
+  @Nested
+  @DisplayName("파일 업로드 메서드")
+  class UploadTest {
+
+    @Test
+    @DisplayName("IOException 발생 시 FileUploadFailedException 발생한다.")
+    void upload_failure_throwsException() throws Exception {
+      // given
+      when(multipartFile.getOriginalFilename()).thenReturn("fail.png");
+      doThrow(new IOException("IO error")).when(multipartFile).transferTo(any(File.class));
+
+      // when + then
+      assertThrows(FileUploadFailedException.class,
+        () -> localFileStorage.upload(multipartFile, FileDomain.PROFILE));
+    }
+  }
+
+  @Nested
+  @DisplayName("파일 삭제 메서드")
+  class RemoveTest {
+
+    @Test
+    @DisplayName("파일 삭제 성공 시 true 반환한다.")
+    void remove_success() throws Exception {
+      // given
+      String path = "http://localhost/files/profile/test.png";
+      Files.createDirectories(Paths.get("upload/profile"));
+      Files.createFile(Paths.get("upload/profile/test.png"));
+
+      // when
+      boolean result = localFileStorage.remove(path);
+
+      // then
+      assertThat(result).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("파일 저장 경로 추출 메서드")
+  class ToStoragePathTest {
+
+    @Test
+    @DisplayName("올바른 URL에서 경로 추출 성공한다.")
+    void toStoragePath_success() {
+      // given
+      String url = "http://localhost/files/profile/test.png";
+
+      // when
+      Path path = localFileStorage.toStoragePath(url);
+
+      // then
+      assertThat(path).isNotNull();
+      assertThat(path.toString()).contains("profile");
+    }
+
+    @Test
+    @DisplayName("잘못된 URL은 IllegalArgumentException")
+    void toStoragePath_invalidUrl() {
+      // given
+      String url = "http://localhost/wrongpath/test.png";
+
+      // when + then
+      assertThrows(IllegalArgumentException.class, () -> localFileStorage.toStoragePath(url));
+    }
+  }
+}
+

--- a/src/test/java/com/part4/team09/otboo/module/domain/file/service/LocalFileStorageTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/file/service/LocalFileStorageTest.java
@@ -10,7 +10,6 @@ import com.part4.team09.otboo.module.domain.file.FileDomain;
 import com.part4.team09.otboo.module.domain.file.exception.FileUploadFailedException;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +36,7 @@ class LocalFileStorageTest {
   void setUp() {
     // 테스트용 값 주입
     ReflectionTestUtils.setField(localFileStorage, "resourcePath", "files");
-    ReflectionTestUtils.setField(localFileStorage, "saveBasePath", Paths.get("test"));
+    ReflectionTestUtils.setField(localFileStorage, "saveBasePath", Paths.get("fileStorage"));
   }
 
   @Nested
@@ -54,26 +53,6 @@ class LocalFileStorageTest {
       // when + then
       assertThrows(FileUploadFailedException.class,
         () -> localFileStorage.upload(multipartFile, FileDomain.PROFILE));
-    }
-  }
-
-  @Nested
-  @DisplayName("파일 삭제 메서드")
-  class RemoveTest {
-
-    @Test
-    @DisplayName("파일 삭제 성공 시 true 반환한다.")
-    void remove_success() throws Exception {
-      // given
-      String path = "http://localhost/files/profile/test.png";
-      Files.createDirectories(Paths.get("upload/profile"));
-      Files.createFile(Paths.get("upload/profile/test.png"));
-
-      // when
-      boolean result = localFileStorage.remove(path);
-
-      // then
-      assertThat(result).isTrue();
     }
   }
 

--- a/src/test/java/com/part4/team09/otboo/module/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/user/service/UserServiceTest.java
@@ -3,15 +3,11 @@ package com.part4.team09.otboo.module.domain.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.part4.team09.otboo.module.domain.location.dto.response.WeatherAPILocation;
 import com.part4.team09.otboo.module.domain.location.repository.DongRepository;
 import com.part4.team09.otboo.module.domain.location.repository.GuRepository;
 import com.part4.team09.otboo.module.domain.location.repository.LocationRepository;
 import com.part4.team09.otboo.module.domain.location.repository.SidoRepository;
-import com.part4.team09.otboo.module.domain.user.dto.ProfileDto;
 import com.part4.team09.otboo.module.domain.user.dto.UserDto;
-import com.part4.team09.otboo.module.domain.user.dto.request.ProfileUpdateRequest;
-import com.part4.team09.otboo.module.domain.user.dto.request.ProfileUpdateRequest.LocationUpdateRequest;
 import com.part4.team09.otboo.module.domain.user.dto.request.UserCreateRequest;
 import com.part4.team09.otboo.module.domain.user.dto.request.UserLockUpdateRequest;
 import com.part4.team09.otboo.module.domain.user.dto.request.UserRoleUpdateRequest;
@@ -19,14 +15,12 @@ import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.entity.User.Role;
 import com.part4.team09.otboo.module.domain.user.exception.EmailAlreadyExistsException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -104,29 +98,5 @@ class UserServiceTest {
 
     // then
     assertThat(userDto.locked()).isEqualTo(true);
-  }
-
-  @DisplayName("위치 정보 변경 시 위치 업데이트를 성공한다.")
-  @Test
-  @Sql(scripts = "/location-update-data.sql")
-  void user_profile_success() {
-    // given : 변경할 위치 정보
-    LocationUpdateRequest locationRequest = new LocationUpdateRequest(37.5000, 127.0364,
-      60, 127, List.of("서울특별시", "강남구", "역삼동"));
-    ProfileUpdateRequest updateRequest = new ProfileUpdateRequest(null, null, null,
-      locationRequest, null);
-
-    // when
-    ProfileDto profileDto = userService.updateProfile(user.getId(), updateRequest, null);
-
-    // then : 위치 정보 변경 확인
-    User user = userRepository.findById(profileDto.userId())
-      .orElseThrow(() -> new RuntimeException("User not found"));
-
-    WeatherAPILocation location = profileDto.location();
-
-    assertThat(user.getLocationId()).isEqualTo("LOC001");
-    assertThat(location.latitude()).isEqualTo(37.5000);
-    assertThat(location.longitude()).isEqualTo(127.0364);
   }
 }

--- a/src/test/java/com/part4/team09/otboo/module/domain/user/service/UserServiceUnitTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/user/service/UserServiceUnitTest.java
@@ -118,8 +118,10 @@ public class UserServiceUnitTest {
       locationRequest, null);
 
     when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-    when(dongRepository.findIdByLatitudeAndLongitude(anyDouble(), anyDouble()))
-      .thenReturn(Optional.empty());
+    when(locationService.getLocationCodeByCoordinates(anyDouble(), anyDouble()))
+      .thenReturn("44729387");
+    when(locationService.getLocation("44729387"))
+      .thenThrow(LocationNotFoundException.withNameAndId("location", "44729387"));
 
     // when & then
     assertThrows(LocationNotFoundException.class,


### PR DESCRIPTION
## Issue Number
#59

## 요약(Summary)
- 위치 정보 업데이트 부분 수정
  - 클라이언트로부터 받아오는 위도, 경도 위치가 DB에 저장된 위도, 경로와 달라 카카오 API를 통해 지역행정코드를 가져와 매칭하도록 변경.
  - 이전에는 바로 DB 데이터에서 위도, 경도로 매칭하여 데이터 불일치 발생

- 파일 업로드 시 retry 추가

- 프로필 파일 삭제 부분 구현
  - fileStorage.remove() 구현
  - 이미지 업데이트 시 이벤트를 통해 이전 프로필 파일을 삭제


## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/1f2097d9-f0f3-40ab-a674-0794acf978b8)


## 공유사항 to 리뷰어


## Close Issue

close #59