### PR TITLE
Refactor: feed mapper 개선

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/SelectableValue/SelectableValueNotFoundException.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/exception/SelectableValue/SelectableValueNotFoundException.java
@@ -2,6 +2,7 @@ package com.part4.team09.otboo.module.domain.clothes.exception.SelectableValue;
 
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesErrorCode;
 import com.part4.team09.otboo.module.domain.clothes.exception.ClothesException;
+import java.util.UUID;
 
 public class SelectableValueNotFoundException extends ClothesException {
 
@@ -12,6 +13,12 @@ public class SelectableValueNotFoundException extends ClothesException {
   public static SelectableValueNotFoundException withItem(String item) {
     SelectableValueNotFoundException exception = new SelectableValueNotFoundException();
     exception.addDetail("item", item);
+    return exception;
+  }
+
+  public static SelectableValueNotFoundException withId(UUID selectableValueId) {
+    SelectableValueNotFoundException exception = new SelectableValueNotFoundException();
+    exception.addDetail("selectableValueId", selectableValueId);
     return exception;
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesAttributeRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesAttributeRepository.java
@@ -11,4 +11,6 @@ public interface ClothesAttributeRepository extends JpaRepository<ClothesAttribu
   void deleteBySelectableValueIdIn(List<UUID> oldValueIds);
 
   void deleteAllByClothesId(UUID clothesId);
+
+  List<ClothesAttribute> findAllByClothesId(UUID clothesId);
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesRepository.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/repository/ClothesRepository.java
@@ -1,10 +1,12 @@
 package com.part4.team09.otboo.module.domain.clothes.repository;
 
 import com.part4.team09.otboo.module.domain.clothes.entity.Clothes;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface ClothesRepository extends JpaRepository<Clothes, UUID> {
 
+  int countByIdIn(List<UUID> ids);
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/controller/FeedController.java
@@ -1,10 +1,10 @@
 package com.part4.team09.otboo.module.domain.feed.controller;
 
-import com.part4.team09.otboo.module.domain.feed.dto.CommentCreateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.CommentCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
-import com.part4.team09.otboo.module.domain.feed.dto.FeedCreateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.FeedCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
-import com.part4.team09.otboo.module.domain.feed.dto.FeedUpdateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.FeedUpdateRequest;
 import com.part4.team09.otboo.module.domain.feed.service.CommentService;
 import com.part4.team09.otboo.module.domain.feed.service.FeedService;
 import com.part4.team09.otboo.module.domain.feed.service.LikeService;

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/controller/FeedController.java
@@ -30,21 +30,27 @@ public class FeedController {
   private final CommentService commentService;
   private final LikeService likeService;
 
+  // TODO: userId @AuthenticationPrincipal로 변경
   @PostMapping
-  public ResponseEntity<FeedDto> createFeed(@RequestBody @Valid FeedCreateRequest request) {
-    FeedDto feedDto = feedService.create(request);
+  public ResponseEntity<FeedDto> createFeed(
+      @RequestParam UUID userId,
+      @RequestBody @Valid FeedCreateRequest request
+  ) {
+    FeedDto feedDto = feedService.create(userId, request);
 
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .body(feedDto);
   }
 
+  // TODO: userId @AuthenticationPrincipal로 변경
   @PatchMapping("/{feedId}")
   public ResponseEntity<FeedDto> updateFeed(
       @PathVariable UUID feedId,
+      @RequestParam UUID userId,
       @RequestBody @Valid FeedUpdateRequest request
   ) {
-    FeedDto feedDto = feedService.update(feedId, request);
+    FeedDto feedDto = feedService.update(feedId, userId, request);
 
     return ResponseEntity
         .status(HttpStatus.OK)

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/FeedDto.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/FeedDto.java
@@ -10,7 +10,7 @@ public record FeedDto(
     UUID id,
     LocalDateTime createdAt,
     LocalDateTime updatedAt,
-    AuthorDto authorDto,
+    AuthorDto author,
     WeatherSummaryDto weather,
     List<OotdDto> ootds,
     String content,

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/FeedDto.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/FeedDto.java
@@ -1,5 +1,6 @@
 package com.part4.team09.otboo.module.domain.feed.dto;
 
+import com.part4.team09.otboo.module.domain.weather.dto.response.WeatherSummaryDto;
 import com.part4.team09.otboo.module.domain.weather.entity.Weather;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,8 +11,7 @@ public record FeedDto(
     LocalDateTime createdAt,
     LocalDateTime updatedAt,
     AuthorDto authorDto,
-    // TODO: WeatherSummaryDto 로 변경
-    Weather weather,
+    WeatherSummaryDto weather,
     List<OotdDto> ootds,
     String content,
     int likeCount,

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/request/CommentCreateRequest.java
@@ -1,4 +1,4 @@
-package com.part4.team09.otboo.module.domain.feed.dto;
+package com.part4.team09.otboo.module.domain.feed.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/request/FeedCreateRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/request/FeedCreateRequest.java
@@ -1,4 +1,4 @@
-package com.part4.team09.otboo.module.domain.feed.dto;
+package com.part4.team09.otboo.module.domain.feed.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/request/FeedUpdateRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/request/FeedUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.part4.team09.otboo.module.domain.feed.dto;
+package com.part4.team09.otboo.module.domain.feed.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/FeedDtoAssembler.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/FeedDtoAssembler.java
@@ -5,6 +5,7 @@ import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.exception.FeedNotFoundException;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
+import com.part4.team09.otboo.module.domain.feed.repository.LikeRepository;
 import com.part4.team09.otboo.module.domain.feed.service.LikeService;
 import com.part4.team09.otboo.module.domain.feed.service.OotdService;
 import com.part4.team09.otboo.module.domain.user.entity.User;
@@ -33,9 +34,9 @@ public class FeedDtoAssembler {
   private final WeatherMapper weatherMapper;
 
   private final OotdService ootdService;
-  private final LikeService likeService;
 
   private final FeedRepository feedRepository;
+  private final LikeRepository likeRepository;
   private final UserRepository userRepository;
   private final WeatherRepository weatherRepository;
   private final PrecipitationRepository precipitationRepository;
@@ -57,7 +58,7 @@ public class FeedDtoAssembler {
 
     WeatherSummaryDto weatherSummary = getWeatherSummaryDto(weather);
     List<OotdDto> ootds = ootdService.getOotds(feed.getId());
-    boolean likedByMe = likeService.isLikedByMe(userId, feed.getId());
+    boolean likedByMe = likeRepository.existsByUserIdAndFeedId(userId, feed.getId());
 
     return feedMapper.toDto(feed, author, weatherSummary, ootds, likedByMe);
   }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/FeedDtoAssembler.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/FeedDtoAssembler.java
@@ -1,0 +1,54 @@
+package com.part4.team09.otboo.module.domain.feed.mapper;
+
+import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
+import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
+import com.part4.team09.otboo.module.domain.feed.entity.Feed;
+import com.part4.team09.otboo.module.domain.feed.exception.FeedNotFoundException;
+import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
+import com.part4.team09.otboo.module.domain.feed.service.LikeService;
+import com.part4.team09.otboo.module.domain.feed.service.OotdService;
+import com.part4.team09.otboo.module.domain.user.entity.User;
+import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
+import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
+import com.part4.team09.otboo.module.domain.weather.entity.Weather;
+import com.part4.team09.otboo.module.domain.weather.exception.WeatherErrorCode;
+import com.part4.team09.otboo.module.domain.weather.exception.WeatherNotFoundException;
+import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FeedDtoAssembler {
+
+  private final FeedMapper feedMapper;
+
+  private final OotdService ootdService;
+  private final LikeService likeService;
+
+  private final FeedRepository feedRepository;
+  private final UserRepository userRepository;
+  private final WeatherRepository weatherRepository;
+
+  public FeedDto assemble(UUID feedId, UUID userId) {
+    Feed feed = feedRepository.findById(feedId)
+        .orElseThrow(() -> FeedNotFoundException.withId(feedId));
+
+    return assemble(feed, userId);
+  }
+
+  public FeedDto assemble(Feed feed, UUID userId) {
+    User author = userRepository.findById(feed.getAuthorId())
+        .orElseThrow(() -> UserNotFoundException.withId(feed.getAuthorId()));
+
+    Weather weather = weatherRepository.findById(feed.getWeatherId())
+        .orElseThrow(() -> WeatherNotFoundException.withId(WeatherErrorCode.WEATHER_NOF_FOUND, feed.getWeatherId()));
+
+    List<OotdDto> ootds = ootdService.getOotds(feed.getId());
+    boolean likedByMe = likeService.isLikedByMe(userId, feed.getId());
+
+    return feedMapper.toDto(feed, author, weather, ootds, likedByMe);
+  }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/FeedDtoAssembler.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/FeedDtoAssembler.java
@@ -10,9 +10,15 @@ import com.part4.team09.otboo.module.domain.feed.service.OotdService;
 import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
+import com.part4.team09.otboo.module.domain.weather.dto.response.WeatherSummaryDto;
+import com.part4.team09.otboo.module.domain.weather.entity.Precipitation;
+import com.part4.team09.otboo.module.domain.weather.entity.Temperature;
 import com.part4.team09.otboo.module.domain.weather.entity.Weather;
 import com.part4.team09.otboo.module.domain.weather.exception.WeatherErrorCode;
 import com.part4.team09.otboo.module.domain.weather.exception.WeatherNotFoundException;
+import com.part4.team09.otboo.module.domain.weather.mapper.WeatherMapper;
+import com.part4.team09.otboo.module.domain.weather.repository.PrecipitationRepository;
+import com.part4.team09.otboo.module.domain.weather.repository.TemperatureRepository;
 import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;
 import java.util.List;
 import java.util.UUID;
@@ -24,6 +30,7 @@ import org.springframework.stereotype.Component;
 public class FeedDtoAssembler {
 
   private final FeedMapper feedMapper;
+  private final WeatherMapper weatherMapper;
 
   private final OotdService ootdService;
   private final LikeService likeService;
@@ -31,6 +38,8 @@ public class FeedDtoAssembler {
   private final FeedRepository feedRepository;
   private final UserRepository userRepository;
   private final WeatherRepository weatherRepository;
+  private final PrecipitationRepository precipitationRepository;
+  private final TemperatureRepository temperatureRepository;
 
   public FeedDto assemble(UUID feedId, UUID userId) {
     Feed feed = feedRepository.findById(feedId)
@@ -42,13 +51,31 @@ public class FeedDtoAssembler {
   public FeedDto assemble(Feed feed, UUID userId) {
     User author = userRepository.findById(feed.getAuthorId())
         .orElseThrow(() -> UserNotFoundException.withId(feed.getAuthorId()));
-
     Weather weather = weatherRepository.findById(feed.getWeatherId())
-        .orElseThrow(() -> WeatherNotFoundException.withId(WeatherErrorCode.WEATHER_NOF_FOUND, feed.getWeatherId()));
+        .orElseThrow(() -> WeatherNotFoundException
+            .withId(WeatherErrorCode.WEATHER_NOF_FOUND, feed.getWeatherId()));
 
+    WeatherSummaryDto weatherSummary = getWeatherSummaryDto(weather);
     List<OotdDto> ootds = ootdService.getOotds(feed.getId());
     boolean likedByMe = likeService.isLikedByMe(userId, feed.getId());
 
-    return feedMapper.toDto(feed, author, weather, ootds, likedByMe);
+    return feedMapper.toDto(feed, author, weatherSummary, ootds, likedByMe);
+  }
+
+  private WeatherSummaryDto getWeatherSummaryDto(Weather weather) {
+    Precipitation precipitation = precipitationRepository.findById(weather.getPrecipitationId())
+        .orElseThrow(() -> WeatherNotFoundException
+            .withId(WeatherErrorCode.PRECIPITATION_NOF_FOUND, weather.getPrecipitationId()));
+
+    Temperature temperature = temperatureRepository.findById(weather.getTemperatureId())
+        .orElseThrow(() -> WeatherNotFoundException
+            .withId(WeatherErrorCode.TEMPERATURE_NOF_FOUND, weather.getTemperatureId()));
+
+    return weatherMapper.toWeatherSummaryDto(
+        weather.getId(),
+        weather.getSkyStatus(),
+        precipitation,
+        temperature
+    );
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/FeedMapper.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/FeedMapper.java
@@ -4,6 +4,7 @@ import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
 import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.user.entity.User;
+import com.part4.team09.otboo.module.domain.weather.dto.response.WeatherSummaryDto;
 import com.part4.team09.otboo.module.domain.weather.entity.Weather;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +16,12 @@ public class FeedMapper {
 
   private final AuthorMapper authorMapper;
 
-  public FeedDto toDto(Feed feed, User author, Weather weather, List<OotdDto> ootdDtos, boolean likedByMe) {
+  public FeedDto toDto(Feed feed, User author, WeatherSummaryDto weather, List<OotdDto> ootdDtos, boolean likedByMe) {
     return  new FeedDto(
         feed.getId(),
         feed.getCreatedAt(),
         feed.getUpdatedAt(),
         authorMapper.toDto(author),
-        // TODO: WeatherSummaryDto 로 변경
         weather,
         ootdDtos,
         feed.getContent(),

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/OotdMapper.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/OotdMapper.java
@@ -4,18 +4,12 @@ import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeWit
 import com.part4.team09.otboo.module.domain.clothes.entity.Clothes;
 import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
 import java.util.List;
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Component
-public class OotdMapper {
+@Mapper(componentModel = "spring")
+public interface OotdMapper {
 
-  public OotdDto toDto(Clothes clothes, List<ClothesAttributeWithDefDto> attributes) {
-    return new OotdDto(
-        clothes.getId(),
-        clothes.getName(),
-        clothes.getImageUrl(),
-        clothes.getType(),
-        attributes
-    );
-  }
+  @Mapping(target = "clothesId", source = "clothes.id")
+  OotdDto toDto(Clothes clothes, List<ClothesAttributeWithDefDto> attributes);
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/OotdMapper.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/mapper/OotdMapper.java
@@ -1,13 +1,21 @@
 package com.part4.team09.otboo.module.domain.feed.mapper;
 
+import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeWithDefDto;
 import com.part4.team09.otboo.module.domain.clothes.entity.Clothes;
 import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import java.util.List;
+import org.springframework.stereotype.Component;
 
-@Mapper(componentModel = "spring")
-public interface OotdMapper {
+@Component
+public class OotdMapper {
 
-  @Mapping(source = "id", target = "clothesId")
-  OotdDto toDto(Clothes clothes);
+  public OotdDto toDto(Clothes clothes, List<ClothesAttributeWithDefDto> attributes) {
+    return new OotdDto(
+        clothes.getId(),
+        clothes.getName(),
+        clothes.getImageUrl(),
+        clothes.getType(),
+        attributes
+    );
+  }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/CommentService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/CommentService.java
@@ -1,6 +1,6 @@
 package com.part4.team09.otboo.module.domain.feed.service;
 
-import com.part4.team09.otboo.module.domain.feed.dto.CommentCreateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.CommentCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Comment;
 import com.part4.team09.otboo.module.domain.feed.exception.FeedNotFoundException;

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/FeedService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/FeedService.java
@@ -7,12 +7,15 @@ import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.entity.Ootd;
 import com.part4.team09.otboo.module.domain.feed.exception.FeedNotFoundException;
+import com.part4.team09.otboo.module.domain.feed.mapper.FeedDtoAssembler;
 import com.part4.team09.otboo.module.domain.feed.mapper.FeedMapper;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
 import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import com.part4.team09.otboo.module.domain.weather.entity.Weather;
+import com.part4.team09.otboo.module.domain.weather.exception.WeatherErrorCode;
+import com.part4.team09.otboo.module.domain.weather.exception.WeatherNotFoundException;
 import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
@@ -28,7 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FeedService {
 
   private final FeedRepository feedRepository;
-  private final FeedMapper feedMapper;
+  private final FeedDtoAssembler feedDtoAssembler;
 
   private final OotdService ootdService;
 
@@ -38,30 +41,24 @@ public class FeedService {
 
   // TODO: 로그인 한 사용자와 같은지 확인
   @Transactional
-  public FeedDto create(FeedCreateRequest request) {
-    User author = getUserOrThrow(request.authorId());
-    Weather weather = getWeatherOrThrow(request.weatherId());
+  public FeedDto create(UUID userId, FeedCreateRequest request) {
+    validateUserExists(request.authorId());
+    validateWeatherExists(request.weatherId());
 
     Feed feed = Feed.create(request.authorId(), request.weatherId(), request.content());
     Feed savedFeed = feedRepository.save(feed);
+    ootdService.create(savedFeed.getId(), request.clothesIds());
 
-    List<OotdDto> ootds = ootdService.create(savedFeed.getId(), request.clothesIds());
-
-    return feedMapper.toDto(savedFeed, author, weather, ootds, false);
+    return feedDtoAssembler.assemble(savedFeed, userId);
   }
 
   // TODO: 로그인 한 사용자와 같은지 확인
   @Transactional
-  public FeedDto update(UUID feedId, FeedUpdateRequest request) {
+  public FeedDto update(UUID feedId, UUID userId, FeedUpdateRequest request) {
     Feed feed = getFeedOrThrow(feedId);
-    User author = getUserOrThrow(feed.getAuthorId());
-    Weather weather = getWeatherOrThrow(feed.getWeatherId());
-    List<OotdDto> ootds = ootdService.getOotds(feedId);
-    boolean likedByMe = likeService.isLikedByMe(author.getId(), feedId);
-
     feed.update(request.content());
 
-    return feedMapper.toDto(feed, author, weather, ootds, likedByMe);
+    return feedDtoAssembler.assemble(feed, userId);
   }
 
   private Feed getFeedOrThrow(UUID feedId) {
@@ -69,14 +66,15 @@ public class FeedService {
         .orElseThrow(() -> FeedNotFoundException.withId(feedId));
   }
 
-  private User getUserOrThrow(UUID userId) {
-    return userRepository.findById(userId)
-        .orElseThrow(() -> UserNotFoundException.withId(userId));
+  private void validateUserExists(UUID userId) {
+    if (!userRepository.existsById(userId)) {
+      throw UserNotFoundException.withId(userId);
+    }
   }
 
-  // TODO: 날씨 커스텀 예외로 변경
-  private Weather getWeatherOrThrow(UUID weatherId) {
-    return weatherRepository.findById(weatherId)
-        .orElseThrow(() -> new EntityNotFoundException("Weather not found with id: " + weatherId));
+  private void validateWeatherExists(UUID weatherId) {
+    if (!weatherRepository.existsById(weatherId)) {
+      throw WeatherNotFoundException.withId(WeatherErrorCode.WEATHER_NOF_FOUND, weatherId);
+    }
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/FeedService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/FeedService.java
@@ -1,8 +1,8 @@
 package com.part4.team09.otboo.module.domain.feed.service;
 
-import com.part4.team09.otboo.module.domain.feed.dto.FeedCreateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.FeedCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
-import com.part4.team09.otboo.module.domain.feed.dto.FeedUpdateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.FeedUpdateRequest;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.exception.FeedNotFoundException;
 import com.part4.team09.otboo.module.domain.feed.mapper.FeedDtoAssembler;

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/LikeService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/LikeService.java
@@ -11,6 +11,8 @@ import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import com.part4.team09.otboo.module.domain.weather.entity.Weather;
+import com.part4.team09.otboo.module.domain.weather.exception.WeatherErrorCode;
+import com.part4.team09.otboo.module.domain.weather.exception.WeatherNotFoundException;
 import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
@@ -31,6 +33,7 @@ public class LikeService {
   private final UserRepository userRepository;
   private final WeatherRepository weatherRepository;
 
+  // TODO: 이미 존재하는 좋아요인지 확인
   @Transactional
   public FeedDto create(UUID userId, UUID feedId) {
     Feed feed = getFeedOrThrow(feedId);
@@ -57,9 +60,8 @@ public class LikeService {
         .orElseThrow(() -> FeedNotFoundException.withId(feedId));
   }
 
-  // TODO: 날씨 커스텀 예외로 변경
   private Weather getWeatherOrThrow(UUID weatherId) {
     return weatherRepository.findById(weatherId)
-        .orElseThrow(() -> new EntityNotFoundException("Weather not found with id: " + weatherId));
+        .orElseThrow(() -> WeatherNotFoundException.withId(WeatherErrorCode.WEATHER_NOF_FOUND, weatherId));
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/LikeService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/LikeService.java
@@ -1,21 +1,13 @@
 package com.part4.team09.otboo.module.domain.feed.service;
 
 import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
-import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.entity.Like;
 import com.part4.team09.otboo.module.domain.feed.exception.FeedNotFoundException;
-import com.part4.team09.otboo.module.domain.feed.mapper.FeedMapper;
+import com.part4.team09.otboo.module.domain.feed.mapper.FeedDtoAssembler;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
 import com.part4.team09.otboo.module.domain.feed.repository.LikeRepository;
-import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
-import com.part4.team09.otboo.module.domain.weather.entity.Weather;
-import com.part4.team09.otboo.module.domain.weather.exception.WeatherErrorCode;
-import com.part4.team09.otboo.module.domain.weather.exception.WeatherNotFoundException;
-import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;
-import jakarta.persistence.EntityNotFoundException;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,41 +19,36 @@ public class LikeService {
 
   private final LikeRepository likeRepository;
 
-  private final FeedMapper feedMapper;
+  private final FeedDtoAssembler feedDtoAssembler;
 
   private final FeedRepository feedRepository;
   private final UserRepository userRepository;
-  private final WeatherRepository weatherRepository;
 
   // TODO: 이미 존재하는 좋아요인지 확인
   @Transactional
   public FeedDto create(UUID userId, UUID feedId) {
-    Feed feed = getFeedOrThrow(feedId);
-    User user = getUserOrThrow(userId);
-    Weather weather = getWeatherOrThrow(feed.getWeatherId());
+    validateFeedExists(feedId);
+    validateUserExists(userId);
 
     Like like = Like.create(feedId, userId);
     likeRepository.save(like);
 
-    return feedMapper.toDto(feed, user, weather, List.of(), true);
+    return feedDtoAssembler.assemble(feedId, userId);
   }
 
   public boolean isLikedByMe(UUID userId, UUID feedId) {
     return likeRepository.existsByUserIdAndFeedId(userId, feedId);
   }
-  
-  private User getUserOrThrow(UUID userId) {
-    return userRepository.findById(userId)
-        .orElseThrow(() -> UserNotFoundException.withId(userId));
+
+  private void validateFeedExists(UUID feedId) {
+    if (!feedRepository.existsById(feedId)) {
+      throw FeedNotFoundException.withId(feedId);
+    }
   }
 
-  private Feed getFeedOrThrow(UUID feedId) {
-    return feedRepository.findById(feedId)
-        .orElseThrow(() -> FeedNotFoundException.withId(feedId));
-  }
-
-  private Weather getWeatherOrThrow(UUID weatherId) {
-    return weatherRepository.findById(weatherId)
-        .orElseThrow(() -> WeatherNotFoundException.withId(WeatherErrorCode.WEATHER_NOF_FOUND, weatherId));
+  private void validateUserExists(UUID userId) {
+    if (!userRepository.existsById(userId)) {
+      throw UserNotFoundException.withId(userId);
+    }
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/OotdService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/OotdService.java
@@ -25,17 +25,13 @@ public class OotdService {
   private final ClothesRepository clothesRepository;
 
   @Transactional
-  public List<OotdDto> create(UUID feedId, List<UUID> clothesIds) {
-    List<Clothes> selectedClothes = getAllByClothesIdsOrThrow(clothesIds);
+  public void create(UUID feedId, List<UUID> clothesIds) {
+    validateAllClothesExist(clothesIds);
     List<Ootd> ootds = clothesIds.stream()
         .map(clothesId -> Ootd.create(feedId, clothesId))
         .toList();
 
     ootdRepository.saveAll(ootds);
-
-    return selectedClothes.stream()
-        .map(ootdMapper::toDto)
-        .toList();
   }
 
   @Transactional(readOnly = true)
@@ -46,6 +42,15 @@ public class OotdService {
     return selectedClothes.stream()
         .map(ootdMapper::toDto)
         .toList();
+  }
+
+  private void validateAllClothesExist(List<UUID> clothesIds) {
+    int foundCount = clothesRepository.countByIdIn(clothesIds);
+
+    // TODO: 의상 커스텀 예외로 변경
+    if (foundCount != clothesIds.size()) {
+      throw new EntityNotFoundException("");
+    }
   }
 
   private List<Clothes> getAllByClothesIdsOrThrow(List<UUID> clothesIds) {

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/OotdService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/OotdService.java
@@ -1,7 +1,17 @@
 package com.part4.team09.otboo.module.domain.feed.service;
 
+import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeWithDefDto;
 import com.part4.team09.otboo.module.domain.clothes.entity.Clothes;
+import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttribute;
+import com.part4.team09.otboo.module.domain.clothes.entity.ClothesAttributeDef;
+import com.part4.team09.otboo.module.domain.clothes.entity.SelectableValue;
+import com.part4.team09.otboo.module.domain.clothes.exception.ClothesAttributeDef.ClothesAttributeDefNotFoundException;
+import com.part4.team09.otboo.module.domain.clothes.exception.SelectableValue.SelectableValueNotFoundException;
+import com.part4.team09.otboo.module.domain.clothes.mapper.ClothesAttributeWithDefMapper;
+import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeDefRepository;
+import com.part4.team09.otboo.module.domain.clothes.repository.ClothesAttributeRepository;
 import com.part4.team09.otboo.module.domain.clothes.repository.ClothesRepository;
+import com.part4.team09.otboo.module.domain.clothes.repository.SelectableValueRepository;
 import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Ootd;
 import com.part4.team09.otboo.module.domain.feed.mapper.OotdMapper;
@@ -21,6 +31,11 @@ public class OotdService {
   private final OotdMapper ootdMapper;
 
   private final ClothesRepository clothesRepository;
+  private final ClothesAttributeDefRepository clothesAttributeDefRepository;
+  private final ClothesAttributeRepository clothesAttributeRepository;
+  private final SelectableValueRepository selectableValueRepository;
+
+  private final ClothesAttributeWithDefMapper clothesAttributeWithDefMapper;
 
   @Transactional
   public void create(UUID feedId, List<UUID> clothesIds) {
@@ -38,7 +53,9 @@ public class OotdService {
     List<Clothes> selectedClothes = getAllByClothesIdsOrThrow(clothesIds);
 
     return selectedClothes.stream()
-        .map(ootdMapper::toDto)
+        .map(clothes ->
+            ootdMapper.toDto(clothes, getAttributes(clothes.getId()))
+        )
         .toList();
   }
 
@@ -73,5 +90,34 @@ public class OotdService {
     }
 
     return foundClothes;
+  }
+
+  private List<ClothesAttributeWithDefDto> getAttributes(UUID clothesId) {
+    List<ClothesAttribute> attributes = clothesAttributeRepository.findAllByClothesId(clothesId);
+
+    List<ClothesAttributeWithDefDto> clothesAttributeWithDefs = attributes.stream()
+        .map(attribute -> {
+          SelectableValue selectValue = selectableValueRepository.findById(attribute.getSelectableValueId())
+              .orElseThrow(() -> SelectableValueNotFoundException.withId(attribute.getSelectableValueId()));
+
+          UUID definitionId = selectValue.getAttributeDefId();
+          ClothesAttributeDef clothesAttributeDef = clothesAttributeDefRepository.findById(definitionId)
+              .orElseThrow(() -> ClothesAttributeDefNotFoundException.withId(definitionId));
+
+          List<String> selectableValues = selectableValueRepository.findAllByAttributeDefId(definitionId)
+              .stream()
+              .map(SelectableValue::getItem)
+              .toList();
+
+          return clothesAttributeWithDefMapper.toDto(
+              definitionId,
+              clothesAttributeDef.getName(),
+              selectableValues,
+              selectValue.getItem()
+          );
+        })
+        .toList();
+
+    return clothesAttributeWithDefs;
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/weather/dto/response/WeatherSummaryDto.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/weather/dto/response/WeatherSummaryDto.java
@@ -1,0 +1,15 @@
+package com.part4.team09.otboo.module.domain.weather.dto.response;
+
+import com.part4.team09.otboo.module.domain.weather.entity.Precipitation;
+import com.part4.team09.otboo.module.domain.weather.entity.Temperature;
+import com.part4.team09.otboo.module.domain.weather.entity.Weather.SkyStatus;
+import java.util.UUID;
+
+public record WeatherSummaryDto(
+    UUID weatherId,
+    SkyStatus skyStatus,
+    Precipitation precipitation,
+    Temperature temperature
+) {
+
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/weather/mapper/WeatherMapper.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/weather/mapper/WeatherMapper.java
@@ -15,6 +15,7 @@ import com.part4.team09.otboo.module.domain.weather.entity.WindSpeed;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface WeatherMapper {
@@ -32,7 +33,7 @@ public interface WeatherMapper {
   );
 
   WeatherSummaryDto toWeatherSummaryDto(
-    UUID id,
+    UUID weatherId,
     SkyStatus skyStatus,
     Precipitation precipitation,
     Temperature temperature

--- a/src/main/java/com/part4/team09/otboo/module/domain/weather/mapper/WeatherMapper.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/weather/mapper/WeatherMapper.java
@@ -5,6 +5,7 @@ import com.part4.team09.otboo.module.domain.weather.dto.response.HumidityDto;
 import com.part4.team09.otboo.module.domain.weather.dto.response.PrecipitationDto;
 import com.part4.team09.otboo.module.domain.weather.dto.response.TemperatureDto;
 import com.part4.team09.otboo.module.domain.weather.dto.response.WeatherDto;
+import com.part4.team09.otboo.module.domain.weather.dto.response.WeatherSummaryDto;
 import com.part4.team09.otboo.module.domain.weather.dto.response.WindSpeedDto;
 import com.part4.team09.otboo.module.domain.weather.entity.Humidity;
 import com.part4.team09.otboo.module.domain.weather.entity.Precipitation;
@@ -30,6 +31,13 @@ public interface WeatherMapper {
     WindSpeedDto windSpeed
   );
 
+  WeatherSummaryDto toWeatherSummaryDto(
+    UUID id,
+    SkyStatus skyStatus,
+    Precipitation precipitation,
+    Temperature temperature
+  );
+
   HumidityDto toHumidityDto(Humidity humidity);
 
   PrecipitationDto toPrecipitationDto(Precipitation precipitation);
@@ -37,5 +45,4 @@ public interface WeatherMapper {
   TemperatureDto toTemperatureDto(Temperature temperature);
 
   WindSpeedDto toWindSpeedDto(WindSpeed windSpeed);
-
 }

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/controller/FeedControllerTest.java
@@ -3,7 +3,6 @@ package com.part4.team09.otboo.module.domain.feed.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -14,17 +13,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.part4.team09.otboo.module.domain.feed.dto.AuthorDto;
-import com.part4.team09.otboo.module.domain.feed.dto.CommentCreateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.CommentCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
-import com.part4.team09.otboo.module.domain.feed.dto.FeedCreateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.FeedCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
-import com.part4.team09.otboo.module.domain.feed.dto.FeedUpdateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.FeedUpdateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
-import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.service.CommentService;
 import com.part4.team09.otboo.module.domain.feed.service.FeedService;
 import com.part4.team09.otboo.module.domain.feed.service.LikeService;
-import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.weather.entity.Weather;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/controller/FeedControllerTest.java
@@ -65,12 +65,13 @@ class FeedControllerTest {
     void create_feed_success() throws Exception {
       // given
       UUID feedId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
       Weather mockWeather = mock(Weather.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
       List<OotdDto> ootdDtos = List.of();
 
       FeedCreateRequest request = new FeedCreateRequest(
-          UUID.randomUUID(),
+          userId,
           UUID.randomUUID(),
           List.of(UUID.randomUUID()),
           "content"
@@ -89,11 +90,12 @@ class FeedControllerTest {
           false
       );
 
-      given(feedService.create(any(FeedCreateRequest.class))).willReturn(feedDto);
+      given(feedService.create(eq(userId), any(FeedCreateRequest.class))).willReturn(feedDto);
 
       // when & then
       mockMvc.perform(post("/api/feeds")
               .contentType(MediaType.APPLICATION_JSON)
+              .param("userId", userId.toString())
               .content(objectMapper.writeValueAsString(request))
               .with(csrf()))
           .andExpect(status().isCreated())
@@ -188,6 +190,7 @@ class FeedControllerTest {
     void update_feed_success() throws Exception {
       // given
       UUID feedId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
       Weather mockWeather = mock(Weather.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
       List<OotdDto> ootdDtos = List.of();
@@ -207,11 +210,12 @@ class FeedControllerTest {
           false
       );
 
-      given(feedService.update(feedId, request)).willReturn(feedDto);
+      given(feedService.update(feedId, userId, request)).willReturn(feedDto);
 
       // when & then
       mockMvc.perform(patch("/api/feeds/{feedId}", feedId)
               .contentType(MediaType.APPLICATION_JSON)
+              .param("userId", userId.toString())
               .content(objectMapper.writeValueAsString(request))
               .with(csrf()))
           .andExpect(status().isOk())

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/controller/FeedControllerTest.java
@@ -22,6 +22,7 @@ import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
 import com.part4.team09.otboo.module.domain.feed.service.CommentService;
 import com.part4.team09.otboo.module.domain.feed.service.FeedService;
 import com.part4.team09.otboo.module.domain.feed.service.LikeService;
+import com.part4.team09.otboo.module.domain.weather.dto.response.WeatherSummaryDto;
 import com.part4.team09.otboo.module.domain.weather.entity.Weather;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -65,7 +66,7 @@ class FeedControllerTest {
       // given
       UUID feedId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
-      Weather mockWeather = mock(Weather.class);
+      WeatherSummaryDto mockWeather = mock(WeatherSummaryDto.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
       List<OotdDto> ootdDtos = List.of();
 
@@ -150,7 +151,7 @@ class FeedControllerTest {
       // given
       UUID feedId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
-      Weather mockWeather = mock(Weather.class);
+      WeatherSummaryDto mockWeather = mock(WeatherSummaryDto.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
       List<OotdDto> ootdDtos = List.of();
 
@@ -190,7 +191,7 @@ class FeedControllerTest {
       // given
       UUID feedId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
-      Weather mockWeather = mock(Weather.class);
+      WeatherSummaryDto mockWeather = mock(WeatherSummaryDto.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
       List<OotdDto> ootdDtos = List.of();
 

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/service/CommentServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/service/CommentServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.part4.team09.otboo.module.domain.feed.dto.AuthorDto;
-import com.part4.team09.otboo.module.domain.feed.dto.CommentCreateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.CommentCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Comment;
 import com.part4.team09.otboo.module.domain.feed.exception.FeedNotFoundException;

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/service/FeedServiceTest.java
@@ -13,6 +13,7 @@ import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
 import com.part4.team09.otboo.module.domain.feed.dto.FeedUpdateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
+import com.part4.team09.otboo.module.domain.feed.mapper.FeedDtoAssembler;
 import com.part4.team09.otboo.module.domain.feed.mapper.FeedMapper;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
 import com.part4.team09.otboo.module.domain.user.entity.User;
@@ -38,7 +39,7 @@ class FeedServiceTest {
   private FeedRepository feedRepository;
 
   @Mock
-  private FeedMapper feedMapper;
+  private FeedDtoAssembler feedDtoAssembler;
 
   @Mock
   private OotdService ootdService;
@@ -63,14 +64,14 @@ class FeedServiceTest {
     @DisplayName("피드 생성 성공")
     void create_feed_success() {
       // given
-      User mockUser = mock(User.class);
+      UUID userId = UUID.randomUUID();
       Weather mockWeather = mock(Weather.class);
       Feed mockFeed = mock(Feed.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
       List<OotdDto> ootdDtos = List.of();
 
       FeedCreateRequest request = new FeedCreateRequest(
-          UUID.randomUUID(),
+          userId,
           UUID.randomUUID(),
           List.of(),
           "content"
@@ -89,14 +90,13 @@ class FeedServiceTest {
           false
       );
 
-      given(userRepository.findById(any())).willReturn(Optional.of(mockUser));
-      given(weatherRepository.findById(any())).willReturn(Optional.of(mockWeather));
+      given(userRepository.existsById(any())).willReturn(true);
+      given(weatherRepository.existsById(any())).willReturn(true);
       given(feedRepository.save(any(Feed.class))).willReturn(mockFeed);
-      given(ootdService.create(any(), any())).willReturn(ootdDtos);
-      given(feedMapper.toDto(any(Feed.class), any(User.class), any(Weather.class), any(), eq(false))).willReturn(feedDto);
+      given(feedDtoAssembler.assemble(any(Feed.class), eq(userId))).willReturn(feedDto);
 
       // when
-      FeedDto result = feedService.create(request);
+      FeedDto result = feedService.create(userId, request);
 
       // then
       assertThat(result).isEqualTo(feedDto);
@@ -113,7 +113,7 @@ class FeedServiceTest {
     void update_feed_success() {
       // given
       UUID feedId = UUID.randomUUID();
-      User mockUser = mock(User.class);
+      UUID userId = UUID.randomUUID();
       Weather mockWeather = mock(Weather.class);
       Feed mockFeed = mock(Feed.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
@@ -133,15 +133,11 @@ class FeedServiceTest {
           false
       );
 
-      given(userRepository.findById(any())).willReturn(Optional.of(mockUser));
       given(feedRepository.findById(any())).willReturn(Optional.of(mockFeed));
-      given(weatherRepository.findById(any())).willReturn(Optional.of(mockWeather));
-      given(ootdService.getOotds(any())).willReturn(List.of());
-      given(likeService.isLikedByMe(any(), any())).willReturn(false);
-      given(feedMapper.toDto(any(Feed.class), any(User.class), any(Weather.class), any(), eq(false))).willReturn(feedDto);
+      given(feedDtoAssembler.assemble(any(Feed.class), eq(userId))).willReturn(feedDto);
 
       // when
-      FeedDto result = feedService.update(feedId, request);
+      FeedDto result = feedService.update(feedId, userId, request);
 
       // then
       assertThat(result).isEqualTo(feedDto);

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/service/FeedServiceTest.java
@@ -16,6 +16,7 @@ import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.mapper.FeedDtoAssembler;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
+import com.part4.team09.otboo.module.domain.weather.dto.response.WeatherSummaryDto;
 import com.part4.team09.otboo.module.domain.weather.entity.Weather;
 import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;
 import java.time.LocalDateTime;
@@ -66,7 +67,7 @@ class FeedServiceTest {
     void create_feed_success() {
       // given
       UUID userId = UUID.randomUUID();
-      Weather mockWeather = mock(Weather.class);
+      WeatherSummaryDto mockWeather = mock(WeatherSummaryDto.class);
       Feed mockFeed = mock(Feed.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
       List<OotdDto> ootdDtos = List.of();
@@ -115,7 +116,7 @@ class FeedServiceTest {
       // given
       UUID feedId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
-      Weather mockWeather = mock(Weather.class);
+      WeatherSummaryDto mockWeather = mock(WeatherSummaryDto.class);
       Feed mockFeed = mock(Feed.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
 

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/service/FeedServiceTest.java
@@ -8,15 +8,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.part4.team09.otboo.module.domain.feed.dto.AuthorDto;
-import com.part4.team09.otboo.module.domain.feed.dto.FeedCreateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.FeedCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
-import com.part4.team09.otboo.module.domain.feed.dto.FeedUpdateRequest;
+import com.part4.team09.otboo.module.domain.feed.dto.request.FeedUpdateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.mapper.FeedDtoAssembler;
-import com.part4.team09.otboo.module.domain.feed.mapper.FeedMapper;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
-import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import com.part4.team09.otboo.module.domain.weather.entity.Weather;
 import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/service/LikeServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/service/LikeServiceTest.java
@@ -12,6 +12,7 @@ import com.part4.team09.otboo.module.domain.feed.dto.AuthorDto;
 import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.exception.FeedNotFoundException;
+import com.part4.team09.otboo.module.domain.feed.mapper.FeedDtoAssembler;
 import com.part4.team09.otboo.module.domain.feed.mapper.FeedMapper;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
 import com.part4.team09.otboo.module.domain.feed.repository.LikeRepository;
@@ -39,16 +40,13 @@ class LikeServiceTest {
   private LikeRepository likeRepository;
 
   @Mock
-  private FeedMapper feedMapper;
+  private FeedDtoAssembler feedDtoAssembler;
 
   @Mock
   private FeedRepository feedRepository;
 
   @Mock
   private UserRepository userRepository;
-
-  @Mock
-  private WeatherRepository weatherRepository;
 
   @InjectMocks
   private LikeService likeService;
@@ -63,9 +61,7 @@ class LikeServiceTest {
       // given
       UUID userId = UUID.randomUUID();
       UUID feedId = UUID.randomUUID();
-      User mockUser = mock(User.class);
       Weather mockWeather = mock(Weather.class);
-      Feed mockFeed = mock(Feed.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
 
       FeedDto feedDto = new FeedDto(
@@ -81,10 +77,9 @@ class LikeServiceTest {
           true
       );
 
-      given(userRepository.findById(any())).willReturn(Optional.of(mockUser));
-      given(feedRepository.findById(any())).willReturn(Optional.of(mockFeed));
-      given(weatherRepository.findById(any())).willReturn(Optional.of(mockWeather));
-      given(feedMapper.toDto(any(Feed.class), any(User.class), any(Weather.class), any(), eq(true))).willReturn(feedDto);
+      given(feedRepository.existsById(any())).willReturn(true);
+      given(userRepository.existsById(any())).willReturn(true);
+      given(feedDtoAssembler.assemble(feedId, userId)).willReturn(feedDto);
 
       // when
       FeedDto result = likeService.create(userId, feedId);
@@ -101,7 +96,7 @@ class LikeServiceTest {
       UUID nonExistFeedId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
 
-      given(feedRepository.findById(nonExistFeedId)).willReturn(Optional.empty());
+      given(feedRepository.existsById(nonExistFeedId)).willReturn(false);
 
       // when & then
       assertThrows(FeedNotFoundException.class,
@@ -116,8 +111,8 @@ class LikeServiceTest {
       Feed mockFeed = mock(Feed.class);
       UUID nonExistUserId = UUID.randomUUID();
 
-      given(feedRepository.findById(feedId)).willReturn(Optional.of(mockFeed));
-      given(userRepository.findById(nonExistUserId)).willReturn(Optional.empty());
+      given(feedRepository.existsById(feedId)).willReturn(true);
+      given(userRepository.existsById(nonExistUserId)).willReturn(false);
 
       // when & then
       assertThrows(UserNotFoundException.class,

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/service/LikeServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/service/LikeServiceTest.java
@@ -19,6 +19,7 @@ import com.part4.team09.otboo.module.domain.feed.repository.LikeRepository;
 import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
+import com.part4.team09.otboo.module.domain.weather.dto.response.WeatherSummaryDto;
 import com.part4.team09.otboo.module.domain.weather.entity.Weather;
 import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;
 import java.time.LocalDateTime;
@@ -61,7 +62,7 @@ class LikeServiceTest {
       // given
       UUID userId = UUID.randomUUID();
       UUID feedId = UUID.randomUUID();
-      Weather mockWeather = mock(Weather.class);
+      WeatherSummaryDto mockWeather = mock(WeatherSummaryDto.class);
       AuthorDto mockAuthorDto = mock(AuthorDto.class);
 
       FeedDto feedDto = new FeedDto(

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/service/OotdServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/service/OotdServiceTest.java
@@ -1,6 +1,5 @@
 package com.part4.team09.otboo.module.domain.feed.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -13,7 +12,6 @@ import com.part4.team09.otboo.module.domain.feed.dto.OotdDto;
 import com.part4.team09.otboo.module.domain.feed.mapper.OotdMapper;
 import com.part4.team09.otboo.module.domain.feed.repository.OotdRepository;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -48,29 +46,14 @@ class OotdServiceTest {
       // given
       UUID feedId = UUID.randomUUID();
       UUID clothedId = UUID.randomUUID();
-
-      OotdDto ootdDto = new OotdDto(
-          clothedId,
-          "name",
-          "imageUrl",
-          ClothesType.BAG,
-          List.of()
-      );
-
       List<UUID> clothesIds = List.of(clothedId);
-      List<OotdDto> ootdDtos = List.of(ootdDto);
-      Clothes mockClothes = mock(Clothes.class);
-      List<Clothes> mockSelectedClothes = List.of(mockClothes);
 
-      given(mockClothes.getId()).willReturn(clothedId);
-      given(clothesRepository.findAllById(clothesIds)).willReturn(mockSelectedClothes);
-      given(ootdMapper.toDto(any(Clothes.class))).willReturn(ootdDto);
+      given(clothesRepository.countByIdIn(clothesIds)).willReturn(1);
 
       // when
-      List<OotdDto> result = ootdService.create(feedId, clothesIds);
+      ootdService.create(feedId, clothesIds);
 
       // then
-      assertThat(result).isEqualTo(ootdDtos);
       verify(ootdRepository).saveAll(any());
     }
   }


### PR DESCRIPTION
## Issue Number
#79 

## 요약(Summary)
- 피드 매퍼를 개선하였습니다.
- 오오티디 매퍼를 개선하였습니다.
- WeatherSummaryDto를 추가하였습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)

## 공유사항 to 리뷰어
```FeedMapper``` 개선을 위해 ```FeedDtoAssembler``` 클래스를 만들었습니다. 다음과 같은 두 가지 이유가 있습니다.
1. FeedDto에 들어가는 데이터가 너무 다양합니다. 유저, 날씨, 옷 정보 등이 전부 들어가는데 이걸 서비스에 있는 메서드(생성, 수정 등)가 항상 조회해서 넘겨주기엔 구조적으로 좋아보이지 않았습니다.
2. 그러면 왜 mapper에서 조회하지 않는가? 입니다. mapper는 데이터를 조회하고 검증하기보단 단순 변환하는 역할이라고 생각했습니다. 따라서, assembler에 feedId, userId(좋아요 여부 확인을 위함)만 넘겨주면 데이터를 조회, 조립한 후 mapper로 넘겨 dto로 변환하는 구조로 구현하였습니다.

FeedDto 사용 시 참고 바랍니다!

## Close Issue

close #79 