### PR TITLE
Fix: 좋아요 중복 등록 시 잘못된 예외 수정 

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/exception/like/LikeAlreadyExistsException.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/exception/like/LikeAlreadyExistsException.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 public class LikeAlreadyExistsException extends FeedException {
 
   public LikeAlreadyExistsException() {
-    super(FeedErrorCode.LIKE_NOT_FOUND);
+    super(FeedErrorCode.LIKE_ALREADY_EXISTS);
   }
 
   public static LikeAlreadyExistsException withId(UUID userId, UUID feedId) {


### PR DESCRIPTION
## Issue Number
#120 

## 요약(Summary)
```LikeAlreadyExistsException```의 에러코드를 ```LIKE_ALREADY_EXISTS```로 변경하였습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)

## 공유사항 to 리뷰어

## Close Issue

close #120