### PR TITLE
Feature: 댓글 목록 조회

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/controller/FeedController.java
@@ -16,14 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/feeds")

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/controller/FeedController.java
@@ -1,6 +1,7 @@
 package com.part4.team09.otboo.module.domain.feed.controller;
 
 import com.part4.team09.otboo.module.common.security.CustomUserDetails;
+import com.part4.team09.otboo.module.domain.feed.dto.CommentDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.feed.dto.request.CommentCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
 import com.part4.team09.otboo.module.domain.feed.dto.request.FeedCreateRequest;
@@ -75,6 +76,21 @@ public class FeedController {
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .body(commentDto);
+  }
+
+  // 댓글 목록 조회
+  @GetMapping("/{feedId}/comments")
+  public ResponseEntity<CommentDtoCursorResponse> getComments(
+          @RequestParam UUID feedId,
+          @RequestParam(required = false) String cursor,
+          @RequestParam(required = false) UUID idAfter,
+          @RequestParam(defaultValue = "10") int limit
+  ){
+    CommentDtoCursorResponse response = commentService.getComments(feedId, cursor, idAfter, limit);
+
+    return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(response);
   }
 
   @PostMapping("/{feedId}/like")

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/CommentDtoCursorResponse.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/CommentDtoCursorResponse.java
@@ -1,0 +1,18 @@
+package com.part4.team09.otboo.module.domain.feed.dto;
+
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+import com.part4.team09.otboo.module.domain.user.dto.UserDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CommentDtoCursorResponse(
+        List<CommentDto> data,
+        String nextCursor,
+        UUID nextIdAfter,
+        boolean hasNext,
+        int totalCount,
+        String sortBy,
+        SortDirection sortDirection
+) {
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/CommentDtoCursorResponse.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/dto/CommentDtoCursorResponse.java
@@ -1,7 +1,6 @@
 package com.part4.team09.otboo.module.domain.feed.dto;
 
 import com.part4.team09.otboo.module.common.enums.SortDirection;
-import com.part4.team09.otboo.module.domain.user.dto.UserDto;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/event/CommentCacheEvictListener.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/event/CommentCacheEvictListener.java
@@ -16,7 +16,7 @@ public class CommentCacheEvictListener {
     private final CacheManager cacheManager;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(CommentCreatedEvent event){
+    public void cacheEvictWhenCommentCreated(CommentCreatedEvent event){
         log.info("댓글 등록시 캐시 무효화 이벤트 처리 시작: feedId = {}", event.feedId());
 
         Cache cache = cacheManager.getCache("comments");
@@ -31,7 +31,7 @@ public class CommentCacheEvictListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(CommentDeletedEvent event){
+    public void cacheEvictWhenCommentDeleted(CommentDeletedEvent event){
         log.info("댓글 삭제시 캐시 무효화 이벤트 처리 시작: feedId = {}", event.feedId());
 
         Cache cache = cacheManager.getCache("comments");

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/event/CommentCacheEvictListener.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/event/CommentCacheEvictListener.java
@@ -1,0 +1,47 @@
+package com.part4.team09.otboo.module.domain.feed.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommentCacheEvictListener {
+
+    private final CacheManager cacheManager;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(CommentCreatedEvent event){
+        log.info("댓글 등록시 캐시 무효화 이벤트 처리 시작: feedId = {}", event.feedId());
+
+        Cache cache = cacheManager.getCache("comments");
+
+        if (cache != null) {
+            cache.evict(event.feedId());
+            log.debug("캐시 무효화 완료: feedId = {}", event.feedId());
+        }else {
+            log.debug("comments 캐시를 찾을 수 없습니다.");
+        }
+        log.info("댓글 등록시 캐시 무효화 이벤트 처리 완료: feedId = {}", event.feedId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(CommentDeletedEvent event){
+        log.info("댓글 삭제시 캐시 무효화 이벤트 처리 시작: feedId = {}", event.feedId());
+
+        Cache cache = cacheManager.getCache("comments");
+
+        if (cache != null) {
+            cache.evict(event.feedId());
+            log.debug("캐시 무효화 완료: feedId = {}", event.feedId());
+        }else {
+            log.debug("comments 캐시를 찾을 수 없습니다.");
+        }
+        log.info("댓글 삭제시 캐시 무효화 이벤트 처리 완료: feedId = {}", event.feedId());
+    }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/event/CommentCreatedEvent.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/event/CommentCreatedEvent.java
@@ -1,0 +1,8 @@
+package com.part4.team09.otboo.module.domain.feed.event;
+
+import java.util.UUID;
+
+public record CommentCreatedEvent(
+        UUID feedId
+) {
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/event/CommentDeletedEvent.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/event/CommentDeletedEvent.java
@@ -1,0 +1,8 @@
+package com.part4.team09.otboo.module.domain.feed.event;
+
+import java.util.UUID;
+
+public record CommentDeletedEvent(
+        UUID feedId
+) {
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/repository/CommentRepositoryQueryDSL.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/repository/CommentRepositoryQueryDSL.java
@@ -1,0 +1,57 @@
+package com.part4.team09.otboo.module.domain.feed.repository;
+
+import com.part4.team09.otboo.module.domain.feed.entity.*;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryQueryDSL {
+
+    private final JPAQueryFactory queryFactory;
+
+    QComment comment = QComment.comment;
+
+    // 댓글 목록 조회
+    public List<Comment> getComments(UUID feedId, String cursor, UUID idAfter, int limit) {
+        return queryFactory
+                .selectFrom(comment)
+                .where(
+                        cursorCondition(cursor, idAfter)
+                )
+                .orderBy(comment.createdAt.asc())
+                .limit(limit)
+                .fetch();
+    }
+
+    // 댓글 개수
+    public int countComments(UUID feedId){
+        Long count = queryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(comment.feedId.eq(feedId))
+                .fetchOne();
+        return count != null ? Math.toIntExact(count) : 0;
+    }
+
+
+    private BooleanExpression cursorCondition(String cursor, UUID idAfter) {
+        if (cursor == null) return null;
+        LocalDateTime decodedCursor = LocalDateTime.parse(cursor);
+
+        BooleanExpression condition = comment.createdAt.gt(decodedCursor);
+
+        if (idAfter != null) {
+            condition = condition.or(
+                    comment.createdAt.eq(decodedCursor).and(comment.id.gt(idAfter))
+            );
+        }
+        return condition;
+    }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/CommentService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/CommentService.java
@@ -18,6 +18,7 @@ import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/CommentService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/CommentService.java
@@ -1,15 +1,21 @@
 package com.part4.team09.otboo.module.domain.feed.service;
 
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+import com.part4.team09.otboo.module.domain.feed.dto.CommentDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.feed.dto.request.CommentCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Comment;
+import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.exception.feed.FeedNotFoundException;
 import com.part4.team09.otboo.module.domain.feed.mapper.CommentMapper;
 import com.part4.team09.otboo.module.domain.feed.repository.CommentRepository;
+import com.part4.team09.otboo.module.domain.feed.repository.CommentRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
 import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
+
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommentService {
 
   private final CommentRepository commentRepository;
+  private final CommentRepositoryQueryDSL commentRepositoryQueryDSL;
   private final CommentMapper commentMapper;
 
   private final FeedRepository feedRepository;
@@ -34,6 +41,42 @@ public class CommentService {
     Comment savedComment = commentRepository.save(comment);
 
     return commentMapper.toDto(savedComment, author);
+  }
+
+  // 댓글 목록 조회
+  @Transactional(readOnly = true)
+  public CommentDtoCursorResponse getComments(UUID feedId, String cursor, UUID idAfter, int limit){
+
+    // 쿼리
+    // 댓글 불러오기
+    List<Comment> comments = commentRepositoryQueryDSL.getComments(feedId, cursor, idAfter, limit+1);
+    int totalCount = commentRepositoryQueryDSL.countComments(feedId);
+
+    Feed feed = feedRepository.findById(feedId).orElseThrow();
+    User author = userRepository.findById(feed.getAuthorId()).orElseThrow();
+
+    // Dto 리스트로 변환
+    List<CommentDto> commentDtos = comments.stream().map(comment -> commentMapper.toDto(comment, author)).toList();
+
+    // 반환
+    // hasNext
+    boolean hasNext = commentDtos.size() > limit;
+    if (hasNext) {
+      commentDtos = commentDtos.subList(0, limit);
+    }
+
+    // nextCursor, nextIdAfter
+    String nextCursor = null;
+    UUID nextIdAfter = null;
+    CommentDto lastCommentDto = null;
+    if (hasNext && commentDtos.size() >= limit) {
+      lastCommentDto = commentDtos.get(limit - 1);
+      nextCursor = lastCommentDto.createdAt().toString();
+      nextIdAfter = lastCommentDto.id();
+    }
+
+    // 최종 반환
+    return new CommentDtoCursorResponse(commentDtos, nextCursor, nextIdAfter, hasNext, totalCount, "createdAt", SortDirection.ASCENDING);
   }
 
   @Transactional

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/CommentService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/CommentService.java
@@ -6,11 +6,14 @@ import com.part4.team09.otboo.module.domain.feed.dto.request.CommentCreateReques
 import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Comment;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
+import com.part4.team09.otboo.module.domain.feed.event.CommentCreatedEvent;
+import com.part4.team09.otboo.module.domain.feed.event.CommentDeletedEvent;
 import com.part4.team09.otboo.module.domain.feed.exception.feed.FeedNotFoundException;
 import com.part4.team09.otboo.module.domain.feed.mapper.CommentMapper;
 import com.part4.team09.otboo.module.domain.feed.repository.CommentRepository;
 import com.part4.team09.otboo.module.domain.feed.repository.CommentRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
+import com.part4.team09.otboo.module.domain.follow.event.FollowCreatedEvent;
 import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
@@ -19,6 +22,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +37,8 @@ public class CommentService {
   private final FeedRepository feedRepository;
   private final UserRepository userRepository;
 
+  private final ApplicationEventPublisher eventPublisher;
+
   @Transactional
   public CommentDto create(UUID feedId, CommentCreateRequest request) {
     validateFeedExists(feedId);
@@ -41,11 +47,14 @@ public class CommentService {
     Comment comment = Comment.create(feedId, request.authorId(), request.content());
     Comment savedComment = commentRepository.save(comment);
 
+    eventPublisher.publishEvent(new CommentCreatedEvent(feedId));
+
     return commentMapper.toDto(savedComment, author);
   }
 
   // 댓글 목록 조회
   @Transactional(readOnly = true)
+  @Cacheable(value = "comments", key = "#feedId", condition = "#cursor == null && #idAfter == null") // 첫 페이지만 캐싱
   public CommentDtoCursorResponse getComments(UUID feedId, String cursor, UUID idAfter, int limit){
 
     // 쿼리
@@ -83,6 +92,8 @@ public class CommentService {
   @Transactional
   public void deleteAllByFeedId(UUID feedId) {
     commentRepository.deleteAllByFeedId(feedId);
+
+    eventPublisher.publishEvent(new CommentDeletedEvent(feedId));
   }
 
   private User getUserOrThrow(UUID userId) {

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/FeedService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/FeedService.java
@@ -1,26 +1,18 @@
 package com.part4.team09.otboo.module.domain.feed.service;
 
-import com.part4.team09.otboo.module.common.enums.SortDirection;
-import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
-import com.part4.team09.otboo.module.domain.feed.dto.CommentDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.feed.dto.request.FeedCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
 import com.part4.team09.otboo.module.domain.feed.dto.request.FeedUpdateRequest;
-import com.part4.team09.otboo.module.domain.feed.entity.Comment;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.exception.feed.FeedNotFoundException;
-import com.part4.team09.otboo.module.domain.feed.mapper.CommentMapper;
 import com.part4.team09.otboo.module.domain.feed.mapper.FeedDtoAssembler;
-import com.part4.team09.otboo.module.domain.feed.repository.CommentRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
-import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import com.part4.team09.otboo.module.domain.weather.exception.WeatherErrorCode;
 import com.part4.team09.otboo.module.domain.weather.exception.WeatherNotFoundException;
 import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;
 
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,8 +30,6 @@ public class FeedService {
   private final OotdService ootdService;
 
   private final CommentService commentService;
-  private final CommentRepositoryQueryDSL commentRepositoryQueryDSL;
-  private final CommentMapper commentMapper;
 
   private final UserRepository userRepository;
   private final WeatherRepository weatherRepository;
@@ -77,43 +67,6 @@ public class FeedService {
 
     feedRepository.deleteById(feedId);
   }
-
-  // 댓글 목록 조회
-  @Transactional(readOnly = true)
-  public CommentDtoCursorResponse getComments(UUID feedId, String cursor, UUID idAfter, int limit){
-
-    // 쿼리
-    // 댓글 불러오기
-    List<Comment> comments = commentRepositoryQueryDSL.getComments(feedId, cursor, idAfter, limit+1);
-    int totalCount = commentRepositoryQueryDSL.countComments(feedId);
-
-    Feed feed = feedRepository.findById(feedId).orElseThrow();
-    User author = userRepository.findById(feed.getAuthorId()).orElseThrow();
-
-    // Dto 리스트로 변환
-    List<CommentDto> commentDtos = comments.stream().map(comment -> commentMapper.toDto(comment, author)).toList();
-
-    // 반환
-    // hasNext
-    boolean hasNext = commentDtos.size() > limit;
-    if (hasNext) {
-      commentDtos = commentDtos.subList(0, limit);
-    }
-
-    // nextCursor, nextIdAfter
-    String nextCursor = null;
-    UUID nextIdAfter = null;
-    CommentDto lastCommentDto = null;
-    if (hasNext && commentDtos.size() >= limit) {
-      lastCommentDto = commentDtos.get(limit - 1);
-      nextCursor = lastCommentDto.createdAt().toString();
-      nextIdAfter = lastCommentDto.id();
-    }
-
-    // 최종 반환
-    return new CommentDtoCursorResponse(commentDtos, nextCursor, nextIdAfter, hasNext, totalCount, "createdAt", SortDirection.ASCENDING);
-  }
-
 
   private Feed getFeedOrThrow(UUID feedId) {
     return feedRepository.findById(feedId)

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/FeedService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/FeedService.java
@@ -1,17 +1,26 @@
 package com.part4.team09.otboo.module.domain.feed.service;
 
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
+import com.part4.team09.otboo.module.domain.feed.dto.CommentDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.feed.dto.request.FeedCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
 import com.part4.team09.otboo.module.domain.feed.dto.request.FeedUpdateRequest;
+import com.part4.team09.otboo.module.domain.feed.entity.Comment;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.exception.feed.FeedNotFoundException;
+import com.part4.team09.otboo.module.domain.feed.mapper.CommentMapper;
 import com.part4.team09.otboo.module.domain.feed.mapper.FeedDtoAssembler;
+import com.part4.team09.otboo.module.domain.feed.repository.CommentRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
+import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import com.part4.team09.otboo.module.domain.weather.exception.WeatherErrorCode;
 import com.part4.team09.otboo.module.domain.weather.exception.WeatherNotFoundException;
 import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;
+
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,9 +35,11 @@ public class FeedService {
 
   private final FeedRepository feedRepository;
   private final FeedDtoAssembler feedDtoAssembler;
-
   private final OotdService ootdService;
+
   private final CommentService commentService;
+  private final CommentRepositoryQueryDSL commentRepositoryQueryDSL;
+  private final CommentMapper commentMapper;
 
   private final UserRepository userRepository;
   private final WeatherRepository weatherRepository;
@@ -66,6 +77,43 @@ public class FeedService {
 
     feedRepository.deleteById(feedId);
   }
+
+  // 댓글 목록 조회
+  @Transactional(readOnly = true)
+  public CommentDtoCursorResponse getComments(UUID feedId, String cursor, UUID idAfter, int limit){
+
+    // 쿼리
+    // 댓글 불러오기
+    List<Comment> comments = commentRepositoryQueryDSL.getComments(feedId, cursor, idAfter, limit+1);
+    int totalCount = commentRepositoryQueryDSL.countComments(feedId);
+
+    Feed feed = feedRepository.findById(feedId).orElseThrow();
+    User author = userRepository.findById(feed.getAuthorId()).orElseThrow();
+
+    // Dto 리스트로 변환
+    List<CommentDto> commentDtos = comments.stream().map(comment -> commentMapper.toDto(comment, author)).toList();
+
+    // 반환
+    // hasNext
+    boolean hasNext = commentDtos.size() > limit;
+    if (hasNext) {
+      commentDtos = commentDtos.subList(0, limit);
+    }
+
+    // nextCursor, nextIdAfter
+    String nextCursor = null;
+    UUID nextIdAfter = null;
+    CommentDto lastCommentDto = null;
+    if (hasNext && commentDtos.size() >= limit) {
+      lastCommentDto = commentDtos.get(limit - 1);
+      nextCursor = lastCommentDto.createdAt().toString();
+      nextIdAfter = lastCommentDto.id();
+    }
+
+    // 최종 반환
+    return new CommentDtoCursorResponse(commentDtos, nextCursor, nextIdAfter, hasNext, totalCount, "createdAt", SortDirection.ASCENDING);
+  }
+
 
   private Feed getFeedOrThrow(UUID feedId) {
     return feedRepository.findById(feedId)

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/event/FollowCacheEvictListener.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/event/FollowCacheEvictListener.java
@@ -1,5 +1,6 @@
 package com.part4.team09.otboo.module.domain.follow.event;
 
+import com.part4.team09.otboo.module.common.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
@@ -14,6 +15,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class FollowCacheEvictListener {
 
     private final CacheManager cacheManager;
+    CustomUserDetails currentUser;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(FollowCreatedEvent event){
@@ -22,8 +24,8 @@ public class FollowCacheEvictListener {
         Cache cache = cacheManager.getCache("followSummary");
 
         if (cache != null) {
-            cache.evict(event.followeeId());
-            cache.evict(event.followerId());
+            cache.evict(event.followeeId().toString() + ":" + currentUser.getId().toString());
+            cache.evict(event.followerId().toString() + ":" + currentUser.getId().toString());
             log.debug("캐시 무효화 완료: followeeId = {}, followerId = {}", event.followeeId(), event.followerId());
         }else {
             log.debug("followSummary 캐시를 찾을 수 없습니다.");
@@ -39,8 +41,8 @@ public class FollowCacheEvictListener {
         Cache cache = cacheManager.getCache("followSummary");
 
         if (cache != null) {
-            cache.evict(event.followeeId());
-            cache.evict(event.followerId());
+            cache.evict(event.followeeId().toString() + ":" + currentUser.getId().toString());
+            cache.evict(event.followerId().toString() + ":" + currentUser.getId().toString());
             log.debug("캐시 무효화 완료: followeeId = {}, followerId = {}", event.followeeId(), event.followerId());
         }else {
             log.debug("followSummary 캐시를 찾을 수 없습니다.");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
     type: redis
     cache-names:
       - followSummary
+      - comments
     redis:
       enable-statistics: true          # size, TTL은 cacheConfig에서 지정
 

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/service/CommentServiceIntegrationTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/service/CommentServiceIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.part4.team09.otboo.module.domain.feed.service;
+
+import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
+import com.part4.team09.otboo.module.domain.feed.dto.CommentDtoCursorResponse;
+import com.part4.team09.otboo.module.domain.feed.entity.Comment;
+import com.part4.team09.otboo.module.domain.feed.entity.Feed;
+import com.part4.team09.otboo.module.domain.feed.repository.CommentRepository;
+import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
+import com.part4.team09.otboo.module.domain.user.entity.User;
+import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class CommentServiceIntegrationTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private CommentService commentService;
+    @Autowired
+    private FeedRepository feedRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    private UUID feedId;
+    private UUID authorId;
+
+    @BeforeEach
+    void setup() {
+        // 1. 사용자 생성, 저장
+        User author = User.createUser("yg@email.com", "연경", "password");
+        userRepository.save(author);
+        authorId = author.getId();
+
+        // 2. 피드 생성, 저장
+        UUID weatherId = UUID.randomUUID();
+        Feed feed = Feed.create(authorId, weatherId, "피드 내용");
+        feedRepository.save(feed);
+        feedId = feed.getId();
+
+        // 3. 댓글 여러개 생성
+        for (int i = 1; i <= 5; i++) {
+            Comment comment = Comment.create(feedId, authorId, "댓글 " + i);
+            commentRepository.save(comment);
+        }
+    }
+
+    @Test
+    @DisplayName("댓글 목록 조회 성공")
+    void getCommentsSuccess() {
+        // when
+        CommentDtoCursorResponse response = commentService.getComments(feedId,null,null,3);
+
+        // then
+        assertThat(response.data()).hasSize(3);
+        assertThat(response.totalCount()).isEqualTo(5);
+        assertThat(response.hasNext()).isTrue(); // 총 5개 중 3개만 불러왔으니 다음 페이지 있음
+        assertThat(response.nextCursor()).isNotNull();
+        assertThat(response.nextIdAfter()).isNotNull();
+
+        List<String> contents = response.data().stream().map(CommentDto::content).toList();
+
+        assertThat(contents).containsExactly("댓글 1", "댓글 2", "댓글 3");
+    }
+}

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/service/CommentServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/service/CommentServiceTest.java
@@ -4,17 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import com.part4.team09.otboo.module.domain.feed.dto.AuthorDto;
 import com.part4.team09.otboo.module.domain.feed.dto.request.CommentCreateRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.CommentDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Comment;
+import com.part4.team09.otboo.module.domain.feed.event.CommentCreatedEvent;
 import com.part4.team09.otboo.module.domain.feed.exception.feed.FeedNotFoundException;
 import com.part4.team09.otboo.module.domain.feed.mapper.CommentMapper;
 import com.part4.team09.otboo.module.domain.feed.repository.CommentRepository;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
+import com.part4.team09.otboo.module.domain.follow.event.FollowDeletedEvent;
 import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
@@ -43,6 +45,9 @@ class CommentServiceTest {
 
   @Mock
   private UserRepository userRepository;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks
   private CommentService commentService;
@@ -78,6 +83,7 @@ class CommentServiceTest {
       given(feedRepository.existsById(any())).willReturn(true);
       given(commentRepository.save(any(Comment.class))).willReturn(mockComment);
       given(commentMapper.toDto(any(Comment.class), any(User.class))).willReturn(commentDto);
+      doNothing().when(eventPublisher).publishEvent(any(CommentCreatedEvent.class));
 
       // when
       CommentDto result = commentService.create(feedId, request);

--- a/src/test/java/com/part4/team09/otboo/module/domain/feed/service/CommentServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/feed/service/CommentServiceTest.java
@@ -15,7 +15,6 @@ import com.part4.team09.otboo.module.domain.feed.exception.feed.FeedNotFoundExce
 import com.part4.team09.otboo.module.domain.feed.mapper.CommentMapper;
 import com.part4.team09.otboo.module.domain.feed.repository.CommentRepository;
 import com.part4.team09.otboo.module.domain.feed.repository.FeedRepository;
-import com.part4.team09.otboo.module.domain.follow.event.FollowDeletedEvent;
 import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;

--- a/src/test/java/com/part4/team09/otboo/module/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/follow/service/FollowServiceTest.java
@@ -1,5 +1,6 @@
 package com.part4.team09.otboo.module.domain.follow.service;
 
+import com.part4.team09.otboo.module.common.security.CustomUserDetails;
 import com.part4.team09.otboo.module.domain.follow.dto.FollowDto;
 import com.part4.team09.otboo.module.domain.follow.dto.FollowListRequest;
 import com.part4.team09.otboo.module.domain.follow.dto.FollowListResponse;
@@ -60,6 +61,9 @@ class FollowServiceTest {
 
     @Mock
     private Cache cache;
+
+    @Mock
+    private CustomUserDetails currentUser;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -294,9 +298,6 @@ class FollowServiceTest {
 
         // when
         followService.deleteFollow(followId);
-
-        // 이벤트 수동 호출
-        followCacheEvictListener.handle(new FollowDeletedEvent(followeeId, followerId));
 
         // then
         verify(followRepository).existsById(followId);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
   sql:
     init:
       mode: never
+  cache:
+    type: none
 
 logging:
   level:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,8 +16,6 @@ spring:
   sql:
     init:
       mode: never
-  cache:
-    type: none
 
 logging:
   level:


### PR DESCRIPTION
## Issue Number
117

## 요약(Summary)
- 피드 댓글 목록 조회 구현
- 조회 캐싱 (첫 페이지만)
- 댓글 등록, 삭제시에 캐시 무효화 이벤트 적용

## PR 유형
feature 

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)

## 공유사항 to 리뷰어
- 단위 테스트 작성 전입니다.
- 통합 테스트 진행 후 PR 합니다.
- 지금 CI 빌드 오류가 나는 이유는 통합테스트가 실패해서입니다. 로컬에서는 잘되는데 CI 때 실패한 이유는 CI 환경에서는 redis 서버가 실행중이 아니기 때문이었습니다. 앞서 피드 목록 조회 부분에서 application-test.yml에 cache type: none 조건을 추가해서 이 부분 해결했습니다. 피드 목록 조회에서 test.yml 파일 머지해와서 해당 브랜치 빌드 문제도 해결했습니다.

## Close Issue

close #117