### PR TITLE
Refactor: 유저 API 접근 권한 설정 및 테스트

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/part4/team09/otboo/module/common/exception/GlobalExceptionHandler.java
@@ -143,6 +143,7 @@ public class GlobalExceptionHandler {
     Cookie cookie = new Cookie(AuthCookieNames.REFRESH_TOKEN_COOKIE_NAME, "");
     cookie.setMaxAge(0);
     cookie.setHttpOnly(true);
+    cookie.setPath("/");
     response.addCookie(cookie);
 
     return createErrorResponseEntity(errorCode.getHttpStatus(), errorResponse);

--- a/src/main/java/com/part4/team09/otboo/module/common/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/part4/team09/otboo/module/common/security/handler/CustomLogoutHandler.java
@@ -46,6 +46,7 @@ public class CustomLogoutHandler implements LogoutHandler {
     Cookie refreshTokenCookie = new Cookie(AuthCookieNames.REFRESH_TOKEN_COOKIE_NAME, "");
     refreshTokenCookie.setMaxAge(0);
     refreshTokenCookie.setHttpOnly(true);
+    refreshTokenCookie.setPath("/");
     response.addCookie(refreshTokenCookie);
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/common/security/handler/JsonLoginSuccessHandler.java
+++ b/src/main/java/com/part4/team09/otboo/module/common/security/handler/JsonLoginSuccessHandler.java
@@ -40,12 +40,13 @@ public class JsonLoginSuccessHandler implements AuthenticationSuccessHandler {
     GeneratedToken generatedToken = jwtTokenProvider.generateToken(authUserDto);
 
     // 쿠키 생성 (refresh token)
-    Cookie tempCookie = new Cookie(AuthCookieNames.REFRESH_TOKEN_COOKIE_NAME,
+    Cookie refreshTokenCookie = new Cookie(AuthCookieNames.REFRESH_TOKEN_COOKIE_NAME,
       generatedToken.refreshToken());
-    tempCookie.setHttpOnly(true);
+    refreshTokenCookie.setHttpOnly(true);
+    refreshTokenCookie.setPath("/");
 
     // 응답 설정
-    response.addCookie(tempCookie);
+    response.addCookie(refreshTokenCookie);
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
     response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/com/part4/team09/otboo/module/domain/user/controller/UserController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/user/controller/UserController.java
@@ -56,6 +56,7 @@ public class UserController {
   }
 
   // 프로필 수정
+  @PreAuthorize("principal.id == #userId")
   @PatchMapping("/{userId}/profiles")
   public ResponseEntity<ProfileDto> updateProfile(
     @PathVariable UUID userId,
@@ -67,6 +68,7 @@ public class UserController {
   }
 
   // 비밀번호 변경
+  @PreAuthorize("principal.id == #userId")
   @PatchMapping("/{userId}/password")
   public ResponseEntity<Void> updatePassword(
     @PathVariable UUID userId,

--- a/src/test/java/com/part4/team09/otboo/module/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,175 @@
+package com.part4.team09.otboo.module.domain.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.part4.team09.otboo.module.domain.user.dto.UserDto;
+import com.part4.team09.otboo.module.domain.user.dto.request.UserListRequest;
+import com.part4.team09.otboo.module.domain.user.dto.request.UserLockUpdateRequest;
+import com.part4.team09.otboo.module.domain.user.dto.request.UserRoleUpdateRequest;
+import com.part4.team09.otboo.module.domain.user.entity.User.Role;
+import com.part4.team09.otboo.module.domain.user.service.UserService;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+@EnableMethodSecurity
+class UserControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private UserService userService;
+
+  UUID userId = UUID.randomUUID();
+  UserDto userDto = new UserDto(userId, LocalDateTime.now(), "test@email.com", "name", Role.ADMIN,
+    null, false);
+
+  @Nested
+  @DisplayName("유저 계정 목록 조회")
+  class GetUsers {
+
+    @Test
+    @DisplayName("ADMIN 권한으로 유저 계정 목록 조회 시 200")
+    @WithMockUser(roles = {"ADMIN"})
+    void getUsers_success() throws Exception {
+      // given
+      UserListRequest request = mock(UserListRequest.class);
+      when(userService.changeRole(any(UUID.class), any(UserRoleUpdateRequest.class))).thenReturn(
+        userDto);
+
+      // when & then
+      mockMvc.perform(get("/api/users", userId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request))
+          .with(csrf()))
+        .andExpect(status().isOk())
+        .andDo(print());
+    }
+
+    @Test
+    @DisplayName("USER 권한으로 유저 계정 목록 조회 시 403 인가 예외")
+    @WithMockUser(roles = {"USER"})
+    void getUsers_shouldThrow_withUserRole() throws Exception {
+      // given
+      UserListRequest request = mock(UserListRequest.class);
+      when(userService.changeRole(any(UUID.class), any(UserRoleUpdateRequest.class))).thenReturn(
+        userDto);
+
+      // when & then
+      mockMvc.perform(get("/api/users", userId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request))
+          .with(csrf()))
+        .andExpect(status().isForbidden())
+        .andDo(print());
+    }
+  }
+
+  @Nested
+  @DisplayName("권한 변경 요청")
+  class ChangeRole {
+
+    @Test
+    @DisplayName("ADMIN 권한으로 권한 변경 요청을 할 경우 200")
+    @WithMockUser(roles = {"ADMIN"})
+    void changeRole_success() throws Exception {
+      // given
+      UserRoleUpdateRequest request = new UserRoleUpdateRequest(Role.ADMIN);
+      when(userService.changeRole(any(UUID.class), any(UserRoleUpdateRequest.class))).thenReturn(
+        userDto);
+
+      // when & then
+      mockMvc.perform(patch("/api/users/{userId}/role", userId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request))
+          .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(userId.toString()))
+        .andDo(print());
+    }
+
+    @Test
+    @DisplayName("USER 권한으로 권한 변경 요청을 할 경우 403 인가 예외")
+    @WithMockUser(roles = {"USER"})
+    void changeRole_shouldThrow_withUserRole() throws Exception {
+      // given
+      UserRoleUpdateRequest request = new UserRoleUpdateRequest(Role.ADMIN);
+      when(userService.changeRole(eq(userId), any(UserRoleUpdateRequest.class))).thenReturn(
+        userDto);
+
+      // when & then
+      mockMvc.perform(patch("/api/users/{userId}/role", userId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request))
+          .with(csrf()))
+        .andExpect(status().isForbidden())
+        .andDo(print());
+    }
+  }
+
+  @Nested
+  @DisplayName("유저 잠금 상태 변경 요청")
+  class ChangeLockStatus {
+
+    @Test
+    @DisplayName("ADMIN 권한으로 유저 잠금 상태 변경 시 200")
+    @WithMockUser(roles = {"ADMIN"})
+    void changeLockStatus_success() throws Exception {
+      // given
+      UserLockUpdateRequest request = new UserLockUpdateRequest(true);
+      when(userService.changeLockStatus(any(UUID.class), any(UserLockUpdateRequest.class)))
+        .thenReturn(userDto);
+
+      // when & then
+      mockMvc.perform(patch("/api/users/{userId}/lock", userId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request))
+          .with(csrf()))
+        .andExpect(status().isOk())
+        .andDo(print());
+    }
+
+    @Test
+    @DisplayName("USER 권한으로 유저 잠금 상태 변경 시 403 인가 예외")
+    @WithMockUser(roles = {"USER"})
+    void changeLockStatus_shouldThrow_withUserRole() throws Exception {
+      // given
+      UserLockUpdateRequest request = new UserLockUpdateRequest(true);
+      when(userService.changeLockStatus(any(UUID.class), any(UserLockUpdateRequest.class)))
+        .thenReturn(userDto);
+
+      // when & then
+      mockMvc.perform(patch("/api/users/{userId}/lock", userId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request))
+          .with(csrf()))
+        .andExpect(status().isOk())
+        .andDo(print());
+    }
+  }
+
+}

--- a/src/test/java/com/part4/team09/otboo/module/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/user/controller/UserControllerTest.java
@@ -235,7 +235,7 @@ class UserControllerTest {
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request))
           .with(csrf()))
-        .andExpect(status().isOk())
+        .andExpect(status().isForbidden())
         .andDo(print());
     }
   }

--- a/src/test/java/com/part4/team09/otboo/module/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/user/controller/UserControllerTest.java
@@ -2,17 +2,27 @@ package com.part4.team09.otboo.module.domain.user.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.part4.team09.otboo.module.common.security.CustomUserDetails;
+import com.part4.team09.otboo.module.domain.auth.dto.AuthUserDto;
+import com.part4.team09.otboo.module.domain.user.dto.ProfileDto;
 import com.part4.team09.otboo.module.domain.user.dto.UserDto;
+import com.part4.team09.otboo.module.domain.user.dto.UserDtoCursorResponse;
+import com.part4.team09.otboo.module.domain.user.dto.request.PasswordUpdateRequest;
+import com.part4.team09.otboo.module.domain.user.dto.request.ProfileUpdateRequest;
 import com.part4.team09.otboo.module.domain.user.dto.request.UserListRequest;
 import com.part4.team09.otboo.module.domain.user.dto.request.UserLockUpdateRequest;
 import com.part4.team09.otboo.module.domain.user.dto.request.UserRoleUpdateRequest;
@@ -26,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -48,6 +59,63 @@ class UserControllerTest {
   UserDto userDto = new UserDto(userId, LocalDateTime.now(), "test@email.com", "name", Role.ADMIN,
     null, false);
 
+  @Test
+  @DisplayName("본인 계정일 때 프로필 수정 200")
+  void updateProfile_success() throws Exception {
+    // given
+    ProfileUpdateRequest updateRequest = mock(ProfileUpdateRequest.class);
+    ProfileDto response = mock(ProfileDto.class);
+
+    AuthUserDto authUserDto = new AuthUserDto(userId, "email", "name", false, Role.USER);
+    CustomUserDetails userDetails = CustomUserDetails.create(authUserDto);
+
+    when(userService.updateProfile(any(UUID.class), any(ProfileUpdateRequest.class),
+      isNull())).thenReturn(response);
+
+    MockMultipartFile jsonPart = new MockMultipartFile(
+      "request",
+      "",
+      "application/json",
+      objectMapper.writeValueAsBytes(updateRequest)
+    );
+
+    // when & then
+    mockMvc.perform(multipart("/api/users/{userId}/profiles", userId)
+        .file(jsonPart)
+        .with(user(userDetails))
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .with(request -> {
+          request.setMethod("PATCH");
+          return request;
+        })
+        .with(csrf()))
+      .andExpect(status().isOk())
+      .andDo(print());
+  }
+
+  @Test
+  @DisplayName("본인 계정이 아닐 때 비밀번호 변경 403 인가 예외")
+  void updatePassword_shouldThrow_IsNotOwner() throws Exception {
+    // given
+    PasswordUpdateRequest request = mock(PasswordUpdateRequest.class);
+
+    UUID anotherUserId = UUID.randomUUID();
+    AuthUserDto authUserDto = new AuthUserDto(anotherUserId, "email", "name", false, Role.USER);
+    CustomUserDetails userDetails = CustomUserDetails.create(authUserDto);
+
+    doNothing().when(userService).updatePassword(any(UUID.class), any(PasswordUpdateRequest.class));
+
+    // when & then
+    mockMvc.perform(get("/api/users", userId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request))
+        .with(user(userDetails))
+        .with(csrf()))
+      .andExpect(status().isForbidden())
+      .andDo(print());
+  }
+
+
   @Nested
   @DisplayName("유저 계정 목록 조회")
   class GetUsers {
@@ -58,8 +126,8 @@ class UserControllerTest {
     void getUsers_success() throws Exception {
       // given
       UserListRequest request = mock(UserListRequest.class);
-      when(userService.changeRole(any(UUID.class), any(UserRoleUpdateRequest.class))).thenReturn(
-        userDto);
+      UserDtoCursorResponse response = mock(UserDtoCursorResponse.class);
+      when(userService.getUsers(any(UserListRequest.class))).thenReturn(response);
 
       // when & then
       mockMvc.perform(get("/api/users", userId)
@@ -76,8 +144,8 @@ class UserControllerTest {
     void getUsers_shouldThrow_withUserRole() throws Exception {
       // given
       UserListRequest request = mock(UserListRequest.class);
-      when(userService.changeRole(any(UUID.class), any(UserRoleUpdateRequest.class))).thenReturn(
-        userDto);
+      UserDtoCursorResponse response = mock(UserDtoCursorResponse.class);
+      when(userService.getUsers(any(UserListRequest.class))).thenReturn(response);
 
       // when & then
       mockMvc.perform(get("/api/users", userId)


### PR DESCRIPTION
## Issue Number
#118

## 요약(Summary)

- 쿠키 path 설정 추가
- user contorlloer 인가 부분 추가 및 테스트
  - 비밀 번호 변경
  - 프로필 수정

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)
- 비밀번호 변경 시 자기 계정인 경우/자기계정이 아닌 경우
<img width="947" height="647" alt="image" src="https://github.com/user-attachments/assets/99c84e3e-a6bc-4308-951d-d6293ab300a0" />

## 공유사항 to 리뷰어

처음에 쿠키 path를 설정하지 않았더니 무효화가 안되는 경우가 있어서 설정 추가했습니다.

인가 테스트를 `@withUserDetails` 을 사용해볼까 했는데 오히려 복잡도만 올라가더라구요..ㅎ
복잡한 인증/인가가 아닌 이상 이정도로도 괜찮은 것 같습니다.

## Close Issue

close #118