### PR TITLE
Fix: 날씨 목록 조회 시 날짜 표기 오류 수정

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/weather/dto/response/WeatherDto.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/weather/dto/response/WeatherDto.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 public record WeatherDto(
   UUID id,
   LocalDateTime forecastedAt,
-  LocalDateTime forecasteAt,
+  LocalDateTime forecastAt,
   WeatherAPILocation location,
   SkyStatus skyStatus,
   PrecipitationDto precipitation,

--- a/src/main/java/com/part4/team09/otboo/module/domain/weather/mapper/WeatherMapper.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/weather/mapper/WeatherMapper.java
@@ -15,7 +15,6 @@ import com.part4.team09.otboo.module.domain.weather.entity.WindSpeed;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface WeatherMapper {
@@ -23,7 +22,7 @@ public interface WeatherMapper {
   WeatherDto toWeatherDto(
     UUID id,
     LocalDateTime forecastedAt,
-    LocalDateTime forecasteAt,
+    LocalDateTime forecastAt,
     WeatherAPILocation location,
     SkyStatus skyStatus,
     PrecipitationDto precipitation,


### PR DESCRIPTION
## Issue Number
#155 
## 요약(Summary)
dto 오타로 인한 날짜 정보 표기 오류 수정
forecasteAt -> forecastAt 'e' 가 포함되어 있었습니다
## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x]버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)

## 공유사항 to 리뷰어

## Close Issue

close #155 