### PR TITLE
Refactor: url로 의상 정보 가져오기 수정

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/controller/ClothesController.java
@@ -119,8 +119,8 @@ public class ClothesController {
 
     ClothesDto response = clothesService.extraction(userDetails.getId(), url);
 
-    log.info("구매 링크 의상 정보 불러오기 응답: name = {}, type = {}, attributeSize = {}, imageUrl = {}",
-        response.name(), response.type(), response.attributes().size(), response.imageUrl());
+    log.info("구매 링크 의상 정보 불러오기 응답: name = {}, type = {}, attribute = {}, imageUrl = {}",
+        response.name(), response.type(), response.attributes(), response.imageUrl());
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/data/ClothesDto.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/data/ClothesDto.java
@@ -1,10 +1,12 @@
 package com.part4.team09.otboo.module.domain.clothes.dto.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.part4.team09.otboo.module.domain.clothes.entity.Clothes.ClothesType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ClothesDto(
 
   // 의상 id

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesCreateRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesCreateRequest.java
@@ -4,7 +4,6 @@ import com.part4.team09.otboo.module.domain.clothes.dto.data.ClothesAttributeDto
 import com.part4.team09.otboo.module.domain.clothes.entity.Clothes.ClothesType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesCreateRequest.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/dto/request/ClothesCreateRequest.java
@@ -16,7 +16,6 @@ public record ClothesCreateRequest(
 
   // 의상 이름
   @NotBlank(message = "의상 이름은 필수입니다.")
-  @Size(max = 50, message = "의상 이름은 50자 이하여야 합니다.")
   String name,
 
   // 의상 타입

--- a/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/clothes/service/ClothesService.java
@@ -233,7 +233,7 @@ public class ClothesService {
       String name = doc.selectFirst("meta[property=og:title]").attr("content");
       String imageUrl = doc.selectFirst("meta[property=og:image]").attr("content");
 
-      return clothesMapper.toDto(null, userId, name, imageUrl, ClothesType.TOP, null, List.of());
+      return clothesMapper.toDto(null, userId, name, imageUrl, null, null, null);
     } catch (RuntimeException e) {
       throw ClothesNotFoundException.withUrl(url);
     }


### PR DESCRIPTION
## Issue Number
#184
## 요약(Summary)
- 이름이 50자 이상일 경우 에러 메시지가 프로토타입에 없어 제거
- 의상 타입 및 의상 속성을 null로 반환하도록 변경

## PR 유형

어떤 변경 사항이 있나요?
### 기존
- 하의에서 생성하더라도 상의로 고정 및 속성이 안보임
<img width="1059" height="771" alt="image" src="https://github.com/user-attachments/assets/90ca1496-5efb-48c3-badf-b9dac17edbbc" />

### 변경
- 의상 종류에 맞게 조정
- 나머지 속성 값 선택 가능
<img width="995" height="736" alt="image" src="https://github.com/user-attachments/assets/5a80cc61-91de-4b30-bce5-8813abfab42b" />

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)

## 공유사항 to 리뷰어

## Close Issue

close #184