### PR TITLE
Refactor: 팔로우 등록 알림 발송 추가 및 좋아요 등록, 삭제시 캐시 무효화 

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/event/FeedCacheEvictListener.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/event/FeedCacheEvictListener.java
@@ -1,5 +1,6 @@
 package com.part4.team09.otboo.module.domain.feed.event;
 
+import com.part4.team09.otboo.module.domain.notification.event.FeedLikedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
@@ -17,18 +18,34 @@ public class FeedCacheEvictListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void cacheEvictWhenFeedCreated(FeedCreatedEvent event){
-        log.info("피드 등록시 캐시 무효화 이벤트 처리 시작");
+        log.info("피드 등록시 생성일순 캐시 무효화 이벤트 처리 시작");
 
         Cache cache = cacheManager.getCache("feeds");
 
         if (cache != null) {
           cache.evict("firstPage:createdAt");
-            log.debug("캐시 무효화 완료");
+            log.debug("피드 등록시 생성일순 캐시 무효화 완료");
         }else {
             log.debug("feeds 캐시를 찾을 수 없습니다.");
         }
 
-        log.info("피드 등록시 캐시 무효화 이벤트 처리 완료");
+        log.info("피드 등록시 생성일순 피드 캐시 무효화 이벤트 처리 완료");
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void cacheEvictWhenLikeCreated(FeedLikedEvent event){
+        log.info("좋아요 등록시 좋아요순 피드 캐시 무효화 이벤트 처리 시작");
+
+        Cache cache = cacheManager.getCache("feeds");
+
+        if (cache != null) {
+            cache.evict("firstPage:likeCount");
+            log.debug("좋아요 등록시 좋아요순 피드 캐시 무효화 완료");
+        }else {
+            log.debug("feeds 캐시를 찾을 수 없습니다.");
+        }
+
+        log.info("좋아요 등록시 좋아요순 피드 캐시 무효화 이벤트 처리 완료");
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -39,11 +56,33 @@ public class FeedCacheEvictListener {
 
         if (cache != null) {
             cache.evict("firstPage:createdAt");
-            log.debug("캐시 무효화 완료");
+            log.debug("피드 삭제시 생성일순 피드 목록 캐시 무효화 완료");
         }else {
             log.debug("feeds 캐시를 찾을 수 없습니다.");
         }
 
+        if (cache != null) {
+            cache.evict("firstPage:likeCount");
+            log.debug("피드 삭제시 좋아요순 피드 목록 캐시 무효화 완료");
+        }else {
+            log.debug("feeds 캐시를 찾을 수 없습니다.");
+        }
         log.info("피드 삭제시 캐시 무효화 이벤트 처리 완료");
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void cacheEvictWhenLikeDeleted(FeedLikeDeletedEvent event){
+        log.info("좋아요 삭제시 좋아요순 캐시 무효화 이벤트 처리 시작");
+
+        Cache cache = cacheManager.getCache("feeds");
+
+        if (cache != null) {
+            cache.evict("firstPage:likeCount");
+            log.debug("좋아요 삭제시 좋아요순 캐시 무효화 완료");
+        }else {
+            log.debug("feeds 캐시를 찾을 수 없습니다.");
+        }
+
+        log.info("좋아요 삭제시 좋아요순 피드 캐시 무효화 이벤트 처리 완료");
     }
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/event/FeedDeletedEvent.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/event/FeedDeletedEvent.java
@@ -1,4 +1,8 @@
 package com.part4.team09.otboo.module.domain.feed.event;
 
-public record FeedDeletedEvent() {
+import java.util.UUID;
+
+public record FeedDeletedEvent(
+        UUID feedId
+) {
 }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/event/FeedLikeDeletedEvent.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/event/FeedLikeDeletedEvent.java
@@ -1,0 +1,4 @@
+package com.part4.team09.otboo.module.domain.feed.event;
+
+public record FeedLikeDeletedEvent() {
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/FeedService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/FeedService.java
@@ -1,8 +1,8 @@
 package com.part4.team09.otboo.module.domain.feed.service;
 
+import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
 import com.part4.team09.otboo.module.domain.feed.dto.FeedDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.feed.dto.request.FeedCreateRequest;
-import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
 import com.part4.team09.otboo.module.domain.feed.dto.request.FeedListRequest;
 import com.part4.team09.otboo.module.domain.feed.dto.request.FeedUpdateRequest;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
@@ -19,10 +19,6 @@ import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import com.part4.team09.otboo.module.domain.weather.exception.WeatherErrorCode;
 import com.part4.team09.otboo.module.domain.weather.exception.WeatherNotFoundException;
 import com.part4.team09.otboo.module.domain.weather.repository.WeatherRepository;
-
-import java.util.List;
-import java.util.UUID;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CachePut;
@@ -31,6 +27,9 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -72,7 +71,7 @@ public class FeedService {
     return feedDtoAssembler.assemble(savedFeed, userId);
   }
 
-  @CachePut(cacheNames="feeds", key="firstPage:createdAt")
+  @CachePut(cacheNames="feeds", key="'firstPage:' +  #request.sortBy()")
   @PreAuthorize("@feedPermissionEvaluator.isFeedAuthor(principal.id, #feedId)")
   @Transactional
   public FeedDto update(UUID feedId, UUID userId, FeedUpdateRequest request) {
@@ -91,7 +90,7 @@ public class FeedService {
     commentService.deleteAllByFeedId(feedId);
     likeService.deleteAllByFeedId(feedId);
 
-    eventPublisher.publishEvent(new FeedDeletedEvent()); // 캐시 무효화 이벤트
+    eventPublisher.publishEvent(new FeedDeletedEvent(feedId)); // 캐시 무효화 이벤트
 
     feedRepository.deleteById(feedId);
   }

--- a/src/main/java/com/part4/team09/otboo/module/domain/feed/service/LikeService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/feed/service/LikeService.java
@@ -3,6 +3,7 @@ package com.part4.team09.otboo.module.domain.feed.service;
 import com.part4.team09.otboo.module.domain.feed.dto.FeedDto;
 import com.part4.team09.otboo.module.domain.feed.entity.Feed;
 import com.part4.team09.otboo.module.domain.feed.entity.Like;
+import com.part4.team09.otboo.module.domain.feed.event.FeedLikeDeletedEvent;
 import com.part4.team09.otboo.module.domain.feed.exception.feed.FeedNotFoundException;
 import com.part4.team09.otboo.module.domain.feed.exception.like.LikeAlreadyExistsException;
 import com.part4.team09.otboo.module.domain.feed.exception.like.LikeNotFoundException;
@@ -13,11 +14,12 @@ import com.part4.team09.otboo.module.domain.notification.event.FeedLikedEvent;
 import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -61,10 +63,14 @@ public class LikeService {
     Like like = getLikeOrThrow(userId, feedId);
     likeRepository.deleteById(like.getId());
     feed.decreaseLikeCount();
+
+    eventPublisher.publishEvent(new FeedLikeDeletedEvent());
   }
 
   public void deleteAllByFeedId(UUID feedId) {
     likeRepository.deleteAllByFeedId(feedId);
+
+    eventPublisher.publishEvent(new FeedLikeDeletedEvent());
   }
 
   private Like getLikeOrThrow(UUID userId, UUID feedId) {

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
@@ -14,16 +14,17 @@ import com.part4.team09.otboo.module.domain.follow.repository.FollowRepository;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -54,8 +55,7 @@ public class FollowService {
 
         log.info("팔로우 저장 완료: id={}", savedFollow.getId());
 
-        // 캐시 무효화 이벤트 pub TODO: 팔로우 당한 사람(팔로이)한테 알림 발송 리스너 추가
-        eventPublisher.publishEvent(new FollowCreatedEvent(followeeId, followerId));
+        eventPublisher.publishEvent(new FollowCreatedEvent(followeeId, followerId)); // 캐시 무효화 이벤트
 
         return followMapper.toDto(savedFollow);
     }

--- a/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/follow/service/FollowService.java
@@ -12,6 +12,7 @@ import com.part4.team09.otboo.module.domain.follow.exception.FollowNotFoundExcep
 import com.part4.team09.otboo.module.domain.follow.mapper.FollowMapper;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepository;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepositoryQueryDSL;
+import com.part4.team09.otboo.module.domain.notification.event.FollowedEvent;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,10 @@ public class FollowService {
     // 팔로우 등록
     @Transactional
     public FollowDto create(UUID followeeId, UUID followerId) {
+        // 알림 발송용 파라미터 준비
+        UUID receiverId = followeeId;
+        String followerName = userRepository.findById(followeeId).orElseThrow().getName();
+
         // 예외처리 1. existsById시 유저가 존재 x    2. 자기자신은 팔로우 불가
         if (!userRepository.existsById(followeeId)) {
             throw UserNotFoundException.withId(followeeId);
@@ -56,6 +61,7 @@ public class FollowService {
         log.info("팔로우 저장 완료: id={}", savedFollow.getId());
 
         eventPublisher.publishEvent(new FollowCreatedEvent(followeeId, followerId)); // 캐시 무효화 이벤트
+        eventPublisher.publishEvent(new FollowedEvent(receiverId, followerName)); // 알림 발송
 
         return followMapper.toDto(savedFollow);
     }

--- a/src/test/java/com/part4/team09/otboo/module/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/follow/service/FollowServiceTest.java
@@ -14,6 +14,7 @@ import com.part4.team09.otboo.module.domain.follow.mapper.FollowMapper;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepository;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.user.dto.UserSummary;
+import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -22,8 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -88,8 +89,18 @@ class FollowServiceTest {
         UserSummary follower = new UserSummary(followerId, name, null);
         FollowDto dto = new FollowDto(fakeId, followee, follower);
 
+        User mockFollowee = User.createUser("dusrud@email.com", name, "password");
+        ReflectionTestUtils.setField(mockFollowee, "id", followeeId);
+        ReflectionTestUtils.setField(mockFollowee, "profileImageUrl", null);
+
+        User mockFollower = User.createUser("dmstn@email.com", name, "password");
+        ReflectionTestUtils.setField(mockFollower, "id", followerId);
+        ReflectionTestUtils.setField(mockFollower, "profileImageUrl", null);
+
 
         when(userRepository.existsById(any(UUID.class))).thenReturn(true); // 유저가 정상적으로 존재할 때를 가정해줌
+        lenient().when(userRepository.findById(followeeId)).thenReturn(Optional.of(mockFollowee));
+        lenient().when(userRepository.findById(followerId)).thenReturn(Optional.of(mockFollower)); // CI 통과를 위한 stub이므로 예외로 stub 허용하기 위한 lenient
         when(followRepository.save(any(Follow.class))).thenReturn(follow);
         when(followMapper.toDto(any(Follow.class))).thenReturn(dto);
         doNothing().when(eventPublisher).publishEvent(any(FollowCreatedEvent.class));


### PR DESCRIPTION
## Issue Number
186

## 요약(Summary)
팔로우 등록 알림 발송 추가 및 좋아요 등록, 삭제시 캐시 무효화 리스너 추가

## PR 유형
refactor

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)

## 공유사항 to 리뷰어
- 알림 발송 추가, 캐시 무효화 같이 PR합니다.
<img width="1583" height="505" alt="image" src="https://github.com/user-attachments/assets/cd247cdb-33f5-4519-997c-e7109d8f78de" />
- 위에는 캐시 무효화 이벤트용, 밑에는 알림 이벤트용인데, 댓글이 생성되었다는 같은 이벤트이니까 추후 하나로 통일하면 좋을 것 같은데, 아예 도메인 내의 리스너 파일이랑 같이 모이게 지금처럼 분리하는 게 나은 건가 싶은 생각도 듭니다. 
- 캐시 무효화 부분 테스트 진행했습니다. 추후 정리해서 스크린샷 첨부해 수정하도록 하겠습니다.

## Close Issue

close #186