### PR TITLE
Feature: 알림 목록 조회 및 DM 목록 조회 테스트

### DIFF
--- a/src/main/java/com/part4/team09/otboo/module/domain/directmessage/controller/DirectMessageController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/directmessage/controller/DirectMessageController.java
@@ -3,6 +3,7 @@ package com.part4.team09.otboo.module.domain.directmessage.controller;
 import com.part4.team09.otboo.module.common.security.CustomUserDetails;
 import com.part4.team09.otboo.module.domain.directmessage.dto.DirectMessageDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.directmessage.service.DirectMessageService;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +29,7 @@ public class DirectMessageController {
       @AuthenticationPrincipal CustomUserDetails currentUser,
       @RequestParam(required = false) String cursor,
       @RequestParam(required = false) UUID idAfter,
-      @RequestParam(defaultValue = "10") int limit
+      @RequestParam(defaultValue = "10") @Min(value = 1, message = "limit은 0보다 커야합니다.") int limit
   ) {
 
     DirectMessageDtoCursorResponse response = directMessageService.getDirectMessages(userId,

--- a/src/main/java/com/part4/team09/otboo/module/domain/directmessage/repository/DirectMessageRepositoryQueryDSL.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/directmessage/repository/DirectMessageRepositoryQueryDSL.java
@@ -54,6 +54,7 @@ public class DirectMessageRepositoryQueryDSL {
                     .from(dm)
                     .where(
                             dm.senderId.eq(currentUserId).and(dm.receiverId.eq(userId))
+                                    .or(dm.senderId.eq(userId).and(dm.receiverId.eq(currentUserId)))
                     )
                     .fetchOne()
         );

--- a/src/main/java/com/part4/team09/otboo/module/domain/directmessage/repository/DirectMessageRepositoryQueryDSL.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/directmessage/repository/DirectMessageRepositoryQueryDSL.java
@@ -25,6 +25,7 @@ public class DirectMessageRepositoryQueryDSL {
 
         condition.and(
                 dm.senderId.eq(currentUserId).and(dm.receiverId.eq(userId))
+                        .or(dm.senderId.eq(userId).and(dm.receiverId.eq(currentUserId)))
         );
 
         // 커서 페이징 조건

--- a/src/main/java/com/part4/team09/otboo/module/domain/directmessage/service/DirectMessageService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/directmessage/service/DirectMessageService.java
@@ -10,21 +10,20 @@ import com.part4.team09.otboo.module.domain.directmessage.entity.DirectMessage;
 import com.part4.team09.otboo.module.domain.directmessage.mapper.DirectMessageDtoAssembler;
 import com.part4.team09.otboo.module.domain.directmessage.repository.DirectMessageRepository;
 import com.part4.team09.otboo.module.domain.directmessage.repository.DirectMessageRepositoryQueryDSL;
-import com.part4.team09.otboo.module.domain.feed.entity.Feed;
-import com.part4.team09.otboo.module.domain.feed.exception.feed.FeedNotFoundException;
 import com.part4.team09.otboo.module.domain.notification.event.DirectMessageReceivedEvent;
 import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/part4/team09/otboo/module/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/notification/controller/NotificationController.java
@@ -1,11 +1,13 @@
 package com.part4.team09.otboo.module.domain.notification.controller;
 
+import com.part4.team09.otboo.module.common.security.CustomUserDetails;
 import com.part4.team09.otboo.module.domain.notification.dto.NotificationDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.notification.service.NotificationService;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -18,11 +20,12 @@ public class NotificationController {
   private final NotificationService notificationService;
 
   @GetMapping
-  public ResponseEntity<NotificationDtoCursorResponse> delete(
+  public ResponseEntity<NotificationDtoCursorResponse> get(
+          @AuthenticationPrincipal CustomUserDetails userDetails,
           @RequestParam(required = false) String cursor,
           @RequestParam(required = false) UUID idAfter,
           @RequestParam(defaultValue = "20") @Min(value = 1, message = "limit은 0보다 커야합니다.") int limit) {
-    NotificationDtoCursorResponse response = notificationService.get(cursor, idAfter, limit);
+    NotificationDtoCursorResponse response = notificationService.get(userDetails.getId(), cursor, idAfter, limit);
 
     return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/main/java/com/part4/team09/otboo/module/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/notification/controller/NotificationController.java
@@ -1,14 +1,14 @@
 package com.part4.team09.otboo.module.domain.notification.controller;
 
+import com.part4.team09.otboo.module.domain.notification.dto.NotificationDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.notification.service.NotificationService;
-import java.util.UUID;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/notifications")
@@ -16,6 +16,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
 
   private final NotificationService notificationService;
+
+  @GetMapping
+  public ResponseEntity<NotificationDtoCursorResponse> delete(
+          @RequestParam(required = false) String cursor,
+          @RequestParam(required = false) UUID idAfter,
+          @RequestParam(defaultValue = "20") @Min(value = 1, message = "limit은 0보다 커야합니다.") int limit) {
+    NotificationDtoCursorResponse response = notificationService.get(cursor, idAfter, limit);
+
+    return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(response);
+  }
 
   @DeleteMapping("/{notificationId}")
   public ResponseEntity<Void> delete(@PathVariable UUID notificationId) {

--- a/src/main/java/com/part4/team09/otboo/module/domain/notification/dto/NotificationDtoCursorResponse.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/notification/dto/NotificationDtoCursorResponse.java
@@ -1,0 +1,17 @@
+package com.part4.team09.otboo.module.domain.notification.dto;
+
+import com.part4.team09.otboo.module.common.enums.SortDirection;
+
+import java.util.List;
+import java.util.UUID;
+
+public record NotificationDtoCursorResponse(
+        List<NotificationDto> data,
+        String nextCursor,
+        UUID nextIdAfter,
+        boolean hasNext,
+        int totalCount,
+        String sortBy,
+        SortDirection sortDirection
+) {
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/notification/repository/NotificationRepositoryQueryDSL.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/notification/repository/NotificationRepositoryQueryDSL.java
@@ -19,31 +19,36 @@ public class NotificationRepositoryQueryDSL {
     private final JPAQueryFactory queryFactory;
     private final QNotification note = QNotification.notification;
 
-    // DM 목록 조회
-    public List<Notification> getNotifications(LocalDateTime cursor, UUID idAfter, int limit) {
+    // 알림 목록 조회
+    public List<Notification> getNotifications(UUID loginUserId, LocalDateTime cursor, UUID idAfter, int limit) {
+        BooleanBuilder condition = new BooleanBuilder();
+        condition.and(note.receiverId.eq(loginUserId)); // 알림 수신자 기준
+
         // 커서 페이징 조건
-        BooleanBuilder cursorCond = new BooleanBuilder();
         if (cursor != null) {
+            BooleanBuilder cursorCond = new BooleanBuilder();
             cursorCond.or(note.createdAt.lt(cursor));
             if (idAfter != null) {
                 cursorCond.or(note.createdAt.eq(cursor).and(note.id.lt(idAfter)));
             }
+            condition.and(cursorCond);
         }
 
         return queryFactory
                 .selectFrom(note)
-                .where(cursorCond)
+                .where(condition)
                 .orderBy(note.createdAt.desc(), note.id.desc())
                 .limit(limit)
                 .fetch();
     }
 
-    // DM 개수
-    public int countNotifications() {
+    // 알림 개수
+    public int countNotifications(UUID loginUserId) {
         return Math.toIntExact(
                 queryFactory
                         .select(note.count())
                         .from(note)
+                        .where(note.receiverId.eq(loginUserId))
                         .fetchOne()
         );
     }

--- a/src/main/java/com/part4/team09/otboo/module/domain/notification/repository/NotificationRepositoryQueryDSL.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/notification/repository/NotificationRepositoryQueryDSL.java
@@ -1,0 +1,50 @@
+package com.part4.team09.otboo.module.domain.notification.repository;
+
+import com.part4.team09.otboo.module.domain.notification.entity.Notification;
+import com.part4.team09.otboo.module.domain.notification.entity.QNotification;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryQueryDSL {
+
+    private final JPAQueryFactory queryFactory;
+    private final QNotification note = QNotification.notification;
+
+    // DM 목록 조회
+    public List<Notification> getNotifications(LocalDateTime cursor, UUID idAfter, int limit) {
+        // 커서 페이징 조건
+        BooleanBuilder cursorCond = new BooleanBuilder();
+        if (cursor != null) {
+            cursorCond.or(note.createdAt.lt(cursor));
+            if (idAfter != null) {
+                cursorCond.or(note.createdAt.eq(cursor).and(note.id.lt(idAfter)));
+            }
+        }
+
+        return queryFactory
+                .selectFrom(note)
+                .where(cursorCond)
+                .orderBy(note.createdAt.desc(), note.id.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    // DM 개수
+    public int countNotifications() {
+        return Math.toIntExact(
+                queryFactory
+                        .select(note.count())
+                        .from(note)
+                        .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/part4/team09/otboo/module/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/notification/service/NotificationService.java
@@ -98,14 +98,15 @@ public class NotificationService {
     );
   }
 
+  // 알림 목록 조회
   @Transactional(readOnly = true)
-  public NotificationDtoCursorResponse get(String cursor, UUID idAfter, int limit){
+  public NotificationDtoCursorResponse get(UUID loginUserId, String cursor, UUID idAfter, int limit){
     // 쿼리
     // cursor을 LocalDateTime으로 디코딩
     LocalDateTime decodedCursor = decodeCursor(cursor);
 
-    List<Notification> notifications = notificationRepositoryQueryDSL.getNotifications(decodedCursor, idAfter, limit + 1);
-    int totalCount = notificationRepositoryQueryDSL.countNotifications();
+    List<Notification> notifications = notificationRepositoryQueryDSL.getNotifications(loginUserId ,decodedCursor, idAfter, limit + 1);
+    int totalCount = notificationRepositoryQueryDSL.countNotifications(loginUserId);
 
     // Dto 리스트로 변환
     List<NotificationDto> notificationDtos = notifications.stream()
@@ -175,7 +176,6 @@ public class NotificationService {
       throw NotificationNotFoundException.withId(notificationId);
     }
   }
-
 
   // cursor 인코딩 로직 (LocalDateTime -> String)
   private String encodeCursor(LocalDateTime cursor) {

--- a/src/main/java/com/part4/team09/otboo/module/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/part4/team09/otboo/module/domain/notification/service/NotificationService.java
@@ -1,31 +1,36 @@
 package com.part4.team09.otboo.module.domain.notification.service;
 
+import com.part4.team09.otboo.module.common.enums.SortDirection;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepository;
-import com.part4.team09.otboo.module.domain.notification.dto.request.NotificationCreateAllRequest;
-import com.part4.team09.otboo.module.domain.notification.dto.request.NotificationCreateFollowerRequest;
-import com.part4.team09.otboo.module.domain.notification.dto.request.NotificationCreateLocationRequest;
-import com.part4.team09.otboo.module.domain.notification.dto.request.NotificationCreateMultipleRequest;
-import com.part4.team09.otboo.module.domain.notification.dto.request.NotificationCreateRequest;
+import com.part4.team09.otboo.module.domain.notification.dto.NotificationDto;
+import com.part4.team09.otboo.module.domain.notification.dto.NotificationDtoCursorResponse;
+import com.part4.team09.otboo.module.domain.notification.dto.request.*;
 import com.part4.team09.otboo.module.domain.notification.entity.Notification;
 import com.part4.team09.otboo.module.domain.notification.event.NotificationCreatedEvent;
 import com.part4.team09.otboo.module.domain.notification.event.NotificationCreatedMultipleEvent;
 import com.part4.team09.otboo.module.domain.notification.exception.NotificationNotFoundException;
 import com.part4.team09.otboo.module.domain.notification.mapper.NotificationMapper;
 import com.part4.team09.otboo.module.domain.notification.repository.NotificationRepository;
+import com.part4.team09.otboo.module.domain.notification.repository.NotificationRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
   private final NotificationRepository notificationRepository;
+  private final NotificationRepositoryQueryDSL notificationRepositoryQueryDSL;
   private final NotificationMapper notificationMapper;
 
   private final UserRepository userRepository;
@@ -38,16 +43,16 @@ public class NotificationService {
     UUID receiverId = request.receiverId();
 
     Notification notification = Notification.create(
-      receiverId,
-      request.title(),
-      request.content(),
-      request.level()
+            receiverId,
+            request.title(),
+            request.content(),
+            request.level()
     );
 
     Notification savedNotification = notificationRepository.save(notification);
 
     eventPublisher.publishEvent(
-      new NotificationCreatedEvent(notificationMapper.toDto(savedNotification))
+            new NotificationCreatedEvent(notificationMapper.toDto(savedNotification))
     );
   }
 
@@ -56,12 +61,12 @@ public class NotificationService {
     List<UUID> allUserIds = userRepository.findAllIds();
 
     createMultiple(
-      allUserIds,
-      new NotificationCreateMultipleRequest(
-        request.title(),
-        request.content(),
-        request.level()
-      )
+            allUserIds,
+            new NotificationCreateMultipleRequest(
+                    request.title(),
+                    request.content(),
+                    request.level()
+            )
     );
   }
 
@@ -70,12 +75,12 @@ public class NotificationService {
     List<UUID> followerIds = followRepository.findFollowerIdsByFolloweeId(request.authorId());
 
     createMultiple(
-      followerIds,
-      new NotificationCreateMultipleRequest(
-        request.title(),
-        request.content(),
-        request.level()
-      )
+            followerIds,
+            new NotificationCreateMultipleRequest(
+                    request.title(),
+                    request.content(),
+                    request.level()
+            )
     );
   }
 
@@ -84,13 +89,50 @@ public class NotificationService {
     List<UUID> userIdsInLocation = userRepository.findUserIdsByLocationId(request.locationId());
 
     createMultiple(
-      userIdsInLocation,
-      new NotificationCreateMultipleRequest(
-        request.title(),
-        request.content(),
-        request.level()
-      )
+            userIdsInLocation,
+            new NotificationCreateMultipleRequest(
+                    request.title(),
+                    request.content(),
+                    request.level()
+            )
     );
+  }
+
+  @Transactional(readOnly = true)
+  public NotificationDtoCursorResponse get(String cursor, UUID idAfter, int limit){
+    // 쿼리
+    // cursor을 LocalDateTime으로 디코딩
+    LocalDateTime decodedCursor = decodeCursor(cursor);
+
+    List<Notification> notifications = notificationRepositoryQueryDSL.getNotifications(decodedCursor, idAfter, limit + 1);
+    int totalCount = notificationRepositoryQueryDSL.countNotifications();
+
+    // Dto 리스트로 변환
+    List<NotificationDto> notificationDtos = notifications.stream()
+            .map(note -> notificationMapper.toDto(note))
+            .toList();
+
+    // 반환
+    // hasNext
+    boolean hasNext = notificationDtos.size() > limit;
+    if (hasNext) {
+      notificationDtos = notificationDtos.subList(0, limit);
+    }
+
+    // nextCursor, nextIdAfter
+    LocalDateTime nextCursor = null;
+    UUID nextIdAfter = null;
+    if (hasNext && !notificationDtos.isEmpty()) {
+      nextCursor = notificationDtos.get(limit - 1).createdAt();
+      nextIdAfter = notificationDtos.get(limit - 1).id();
+    }
+
+    // nextCursor 인코딩
+    String encodedNextCursor = encodeCursor(nextCursor);
+
+    // 최종 반환
+    return new NotificationDtoCursorResponse(notificationDtos, encodedNextCursor, nextIdAfter,
+            hasNext, totalCount, "createdAt, id", SortDirection.DESCENDING);
   }
 
   @PreAuthorize("@notificationPermissionEvaluator.isNotificationReceiver(principal.id, #notificationId)")
@@ -101,24 +143,30 @@ public class NotificationService {
     notificationRepository.deleteById(notificationId);
   }
 
+  private String createDmKey(UUID senderId, UUID receiverId) {
+    List<UUID> ids = Arrays.asList(senderId, receiverId);
+    ids.sort(Comparator.comparing(UUID::toString));
+    return ids.get(0) + "_" + ids.get(1);
+  }
+
   private void createMultiple(List<UUID> receiverIds, NotificationCreateMultipleRequest request) {
     List<Notification> notifications = receiverIds.stream()
-      .map(id -> Notification.create(
-        id,
-        request.title(),
-        request.content(),
-        request.level()
-      ))
-      .toList();
+            .map(id -> Notification.create(
+                    id,
+                    request.title(),
+                    request.content(),
+                    request.level()
+            ))
+            .toList();
 
     List<Notification> savedNotifications = notificationRepository.saveAll(notifications);
 
     eventPublisher.publishEvent(
-      new NotificationCreatedMultipleEvent(
-        savedNotifications.stream()
-          .map(notificationMapper::toDto)
-          .toList()
-      )
+            new NotificationCreatedMultipleEvent(
+                    savedNotifications.stream()
+                            .map(notificationMapper::toDto)
+                            .toList()
+            )
     );
   }
 
@@ -126,5 +174,16 @@ public class NotificationService {
     if (!notificationRepository.existsById(notificationId)) {
       throw NotificationNotFoundException.withId(notificationId);
     }
+  }
+
+
+  // cursor 인코딩 로직 (LocalDateTime -> String)
+  private String encodeCursor(LocalDateTime cursor) {
+    return cursor == null ? null : cursor.toString();
+  }
+
+  // cursor 디코딩 로직 (String -> LocalDateTime)
+  private LocalDateTime decodeCursor(String cursor) {
+    return cursor == null || cursor.isEmpty() ? null : LocalDateTime.parse(cursor);
   }
 }

--- a/src/test/java/com/part4/team09/otboo/module/domain/directmessage/repository/DirectMessageRepositoryQueryDSLTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/directmessage/repository/DirectMessageRepositoryQueryDSLTest.java
@@ -1,0 +1,119 @@
+package com.part4.team09.otboo.module.domain.directmessage.repository;
+
+import com.part4.team09.otboo.module.domain.directmessage.entity.DirectMessage;
+import com.part4.team09.otboo.module.domain.directmessage.entity.QDirectMessage;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DirectMessageRepositoryQueryDSLTest {
+
+    @Mock
+    private JPAQueryFactory queryFactory;
+
+    @InjectMocks
+    private DirectMessageRepositoryQueryDSL directMessageRepositoryQueryDSL;
+
+    private QDirectMessage dm = QDirectMessage.directMessage;
+
+    @Test
+    @DisplayName("getDirectMessages - 커서 없이 기본 조회")
+    void getDirectMessages_noCursor() {
+        UUID userId = UUID.randomUUID();
+        UUID currentUserId = UUID.randomUUID();
+
+        JPAQuery<DirectMessage> jpaQuery = mock(JPAQuery.class);
+
+        // 조건에 따라 호출될 메서드들 mocking
+        when(queryFactory.selectFrom(dm)).thenReturn(jpaQuery);
+        when(jpaQuery.where(any(Predicate.class))).thenReturn(jpaQuery);
+        when(jpaQuery.orderBy(any(OrderSpecifier.class), any(OrderSpecifier.class))).thenReturn(jpaQuery);
+        when(jpaQuery.limit(anyLong())).thenReturn(jpaQuery);
+
+        // 결과용 리스트
+        List<DirectMessage> expected = List.of(mock(DirectMessage.class));
+        when(jpaQuery.fetch()).thenReturn(expected);
+
+        // 실제 메서드 호출
+        List<DirectMessage> result = directMessageRepositoryQueryDSL.getDirectMessages(userId, currentUserId, null, null, 10);
+
+        assertThat(result).isEqualTo(expected);
+
+        // 메서드 호출 확인
+        verify(queryFactory).selectFrom(dm);
+        verify(jpaQuery).where(any(Predicate.class));
+        verify(jpaQuery).orderBy(dm.createdAt.asc(), dm.id.asc());
+        verify(jpaQuery).limit(10);
+        verify(jpaQuery).fetch();
+    }
+
+    @Test
+    @DisplayName("getDirectMessages - 커서와 idAfter 조건 포함 조회")
+    void getDirectMessages_withCursorAndIdAfter() {
+        UUID userId = UUID.randomUUID();
+        UUID currentUserId = UUID.randomUUID();
+        LocalDateTime cursor = LocalDateTime.now().minusDays(1);
+        UUID idAfter = UUID.randomUUID();
+
+        JPAQuery<DirectMessage> jpaQuery = mock(JPAQuery.class);
+
+        when(queryFactory.selectFrom(dm)).thenReturn(jpaQuery);
+        when(jpaQuery.where(any(Predicate.class))).thenReturn(jpaQuery);
+        when(jpaQuery.orderBy(any(OrderSpecifier.class), any(OrderSpecifier.class))).thenReturn(jpaQuery);
+        when(jpaQuery.limit(anyLong())).thenReturn(jpaQuery);
+
+        List<DirectMessage> expected = List.of(mock(DirectMessage.class));
+        when(jpaQuery.fetch()).thenReturn(expected);
+
+        List<DirectMessage> result = directMessageRepositoryQueryDSL.getDirectMessages(userId, currentUserId, cursor, idAfter, 5);
+
+        assertThat(result).isEqualTo(expected);
+
+        verify(queryFactory).selectFrom(dm);
+        verify(jpaQuery).where(any(Predicate.class));
+        verify(jpaQuery).orderBy(dm.createdAt.asc(), dm.id.asc());
+        verify(jpaQuery).limit(5);
+        verify(jpaQuery).fetch();
+    }
+
+    @Test
+    @DisplayName("countDirectMessages - 개수 조회")
+    void countDirectMessagesSuccess() {
+        UUID userId = UUID.randomUUID();
+        UUID currentUserId = UUID.randomUUID();
+
+        // Mock QueryDSL 반환 타입 Long
+        JPAQuery<Long> countQuery = mock(JPAQuery.class);
+
+        when(queryFactory.select(dm.count())).thenReturn(countQuery);
+        when(countQuery.from(dm)).thenReturn(countQuery);
+        when(countQuery.where(any(Predicate.class))).thenReturn(countQuery);
+        when(countQuery.fetchOne()).thenReturn(7L);
+
+        int count = directMessageRepositoryQueryDSL.countDirectMessages(userId, currentUserId);
+
+        assertThat(count).isEqualTo(7);
+
+        verify(queryFactory).select(dm.count());
+        verify(countQuery).from(dm);
+        verify(countQuery).where(any(Predicate.class));
+        verify(countQuery).fetchOne();
+    }
+}

--- a/src/test/java/com/part4/team09/otboo/module/domain/directmessage/service/DirectMessageServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/directmessage/service/DirectMessageServiceTest.java
@@ -1,20 +1,17 @@
 package com.part4.team09.otboo.module.domain.directmessage.service;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-
+import com.part4.team09.otboo.module.common.security.CustomUserDetails;
 import com.part4.team09.otboo.module.domain.directmessage.dto.DirectMessageDto;
+import com.part4.team09.otboo.module.domain.directmessage.dto.DirectMessageDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.directmessage.dto.DirectMessageSendPayload;
 import com.part4.team09.otboo.module.domain.directmessage.dto.request.DirectMessageCreateRequest;
 import com.part4.team09.otboo.module.domain.directmessage.entity.DirectMessage;
 import com.part4.team09.otboo.module.domain.directmessage.mapper.DirectMessageDtoAssembler;
 import com.part4.team09.otboo.module.domain.directmessage.repository.DirectMessageRepository;
+import com.part4.team09.otboo.module.domain.directmessage.repository.DirectMessageRepositoryQueryDSL;
+import com.part4.team09.otboo.module.domain.user.dto.UserSummary;
 import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
-import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,12 +20,29 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DirectMessageServiceTest {
 
   @Mock
   private DirectMessageRepository directMessageRepository;
+
+  @Mock
+  private DirectMessageRepositoryQueryDSL directMessageRepositoryQueryDSL;
 
   @Mock
   private DirectMessageDtoAssembler directMessageDtoAssembler;
@@ -74,5 +88,45 @@ class DirectMessageServiceTest {
       // then
       assertEquals(mockDirectMessageDto, result.directMessageDto());
     }
+  }
+
+  @Test
+  @DisplayName("DM 목록 조회 성공")
+  void getDirectMessagesSuccess() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UUID currentUserId = UUID.randomUUID();
+    CustomUserDetails currentUser = mock(CustomUserDetails.class);
+    when(currentUser.getId()).thenReturn(currentUserId);
+    when(userRepository.existsById(userId)).thenReturn(true);
+
+    // DirectMessage 엔티티 생성
+    DirectMessage dm = DirectMessage.create(UUID.randomUUID(), UUID.randomUUID(), "안녕");
+    ReflectionTestUtils.setField(dm, "id", UUID.randomUUID());
+    ReflectionTestUtils.setField(dm, "createdAt", LocalDateTime.now());
+
+    // Repository에서 1개 메시지 리턴하도록 mocking
+    when(directMessageRepositoryQueryDSL.getDirectMessages(any(), any(), any(), any(), anyInt()))
+            .thenReturn(List.of(dm));
+    when(directMessageRepositoryQueryDSL.countDirectMessages(any(), any())).thenReturn(1);
+
+    // DTO 변환 mocking
+    DirectMessageDto dto = new DirectMessageDto(
+            (UUID) ReflectionTestUtils.getField(dm, "id"),
+            (LocalDateTime) ReflectionTestUtils.getField(dm, "createdAt"),
+            new UserSummary(dm.getSenderId(), "sender", null),
+            new UserSummary(dm.getReceiverId(), "receiver", null),
+            dm.getContent()
+    );
+    when(directMessageDtoAssembler.assemble(dm)).thenReturn(dto);
+
+    // when
+    DirectMessageDtoCursorResponse result = directMessageService.getDirectMessages(userId, currentUser, null, null, 10);
+
+    // then
+    assertThat(result).isNotNull();                     // 결과가 null 아니어야 함
+    assertThat(result.data()).hasSize(1);       // 데이터 1개 리턴 확인
+    assertThat(result.hasNext()).isFalse();             // 다음 페이지 없음을 확인
+    assertThat(result.totalCount()).isEqualTo(1); // 총 메시지 개수 확인
   }
 }

--- a/src/test/java/com/part4/team09/otboo/module/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/follow/service/FollowServiceTest.java
@@ -14,6 +14,7 @@ import com.part4.team09.otboo.module.domain.follow.mapper.FollowMapper;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepository;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.user.dto.UserSummary;
+import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -22,8 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -88,8 +89,18 @@ class FollowServiceTest {
         UserSummary follower = new UserSummary(followerId, name, null);
         FollowDto dto = new FollowDto(fakeId, followee, follower);
 
+        User mockFollowee = User.createUser("dusrud@email.com", name, "password");
+        ReflectionTestUtils.setField(mockFollowee, "id", followeeId);
+        ReflectionTestUtils.setField(mockFollowee, "profileImageUrl", null);
+
+        User mockFollower = User.createUser("dmstn@email.com", name, "password");
+        ReflectionTestUtils.setField(mockFollower, "id", followerId);
+        ReflectionTestUtils.setField(mockFollower, "profileImageUrl", null);
+
 
         when(userRepository.existsById(any(UUID.class))).thenReturn(true); // 유저가 정상적으로 존재할 때를 가정해줌
+        lenient().when(userRepository.findById(followeeId)).thenReturn(Optional.of(mockFollowee));
+        lenient().when(userRepository.findById(followerId)).thenReturn(Optional.of(mockFollower)); // CI 통과를 위한 stub이므로 예외로 stub 허용하기 위한 lenient
         when(followRepository.save(any(Follow.class))).thenReturn(follow);
         when(followMapper.toDto(any(Follow.class))).thenReturn(dto);
         doNothing().when(eventPublisher).publishEvent(any(FollowCreatedEvent.class));

--- a/src/test/java/com/part4/team09/otboo/module/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/follow/service/FollowServiceTest.java
@@ -14,7 +14,6 @@ import com.part4.team09.otboo.module.domain.follow.mapper.FollowMapper;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepository;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.user.dto.UserSummary;
-import com.part4.team09.otboo.module.domain.user.entity.User;
 import com.part4.team09.otboo.module.domain.user.exception.UserNotFoundException;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -89,18 +88,7 @@ class FollowServiceTest {
         UserSummary follower = new UserSummary(followerId, name, null);
         FollowDto dto = new FollowDto(fakeId, followee, follower);
 
-        User mockFollowee = User.createUser("dusrud@email.com", name, "password");
-        ReflectionTestUtils.setField(mockFollowee, "id", followeeId);
-        ReflectionTestUtils.setField(mockFollowee, "profileImageUrl", null);
-
-        User mockFollower = User.createUser("dmstn@email.com", name, "password");
-        ReflectionTestUtils.setField(mockFollower, "id", followerId);
-        ReflectionTestUtils.setField(mockFollower, "profileImageUrl", null);
-
-
         when(userRepository.existsById(any(UUID.class))).thenReturn(true); // 유저가 정상적으로 존재할 때를 가정해줌
-        lenient().when(userRepository.findById(followeeId)).thenReturn(Optional.of(mockFollowee));
-        lenient().when(userRepository.findById(followerId)).thenReturn(Optional.of(mockFollower)); // CI 통과를 위한 stub이므로 예외로 stub 허용하기 위한 lenient
         when(followRepository.save(any(Follow.class))).thenReturn(follow);
         when(followMapper.toDto(any(Follow.class))).thenReturn(dto);
         doNothing().when(eventPublisher).publishEvent(any(FollowCreatedEvent.class));

--- a/src/test/java/com/part4/team09/otboo/module/domain/notification/repository/NotificationRepositoryQueryDSLTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/notification/repository/NotificationRepositoryQueryDSLTest.java
@@ -1,0 +1,85 @@
+package com.part4.team09.otboo.module.domain.notification.repository;
+
+import com.part4.team09.otboo.module.domain.notification.entity.Notification;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class NotificationRepositoryQueryDSLTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private NotificationRepositoryQueryDSL notificationRepositoryQueryDSL;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Test
+    @DisplayName("알림 목록 조회 성공")
+    void getNotifications_성공() {
+        // given
+        UUID receiverId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+
+        for (int i = 0; i < 5; i++) {
+            Notification notification = Notification.create(
+                    receiverId,
+                    "제목" + i,
+                    "내용" + i,
+                    Notification.Level.INFO
+            );
+            ReflectionTestUtils.setField(notification, "createdAt", now.minusMinutes(4 - i));
+            notificationRepository.save(notification);
+        }
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<Notification> result = notificationRepositoryQueryDSL.getNotifications(receiverId, null, null, 5);
+
+        // then
+        assertThat(result).hasSize(5);
+        assertThat(result.get(0).getContent()).isEqualTo("내용4");
+        assertThat(result.get(4).getContent()).isEqualTo("내용0");
+    }
+
+    @Test
+    @DisplayName("알림 개수 조회 성공")
+    void countNotificationsSuccess() {
+        // given
+        UUID receiverId = UUID.randomUUID();
+        for (int i = 0; i < 3; i++) {
+            Notification notification = Notification.create(
+                    receiverId,
+                    "제목" + i,
+                    "내용" + i,
+                    Notification.Level.WARNING
+            );
+            notificationRepository.save(notification);
+        }
+
+        // when
+        int count = notificationRepositoryQueryDSL.countNotifications(receiverId);
+
+        // then
+        assertThat(count).isEqualTo(3);
+    }
+}

--- a/src/test/java/com/part4/team09/otboo/module/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/part4/team09/otboo/module/domain/notification/service/NotificationServiceTest.java
@@ -1,20 +1,19 @@
 package com.part4.team09.otboo.module.domain.notification.service;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-
+import com.part4.team09.otboo.module.common.enums.SortDirection;
 import com.part4.team09.otboo.module.domain.follow.repository.FollowRepository;
+import com.part4.team09.otboo.module.domain.notification.dto.NotificationDto;
+import com.part4.team09.otboo.module.domain.notification.dto.NotificationDtoCursorResponse;
 import com.part4.team09.otboo.module.domain.notification.dto.request.NotificationCreateAllRequest;
 import com.part4.team09.otboo.module.domain.notification.dto.request.NotificationCreateFollowerRequest;
 import com.part4.team09.otboo.module.domain.notification.dto.request.NotificationCreateLocationRequest;
 import com.part4.team09.otboo.module.domain.notification.dto.request.NotificationCreateRequest;
+import com.part4.team09.otboo.module.domain.notification.entity.Notification;
 import com.part4.team09.otboo.module.domain.notification.entity.Notification.Level;
 import com.part4.team09.otboo.module.domain.notification.mapper.NotificationMapper;
 import com.part4.team09.otboo.module.domain.notification.repository.NotificationRepository;
+import com.part4.team09.otboo.module.domain.notification.repository.NotificationRepositoryQueryDSL;
 import com.part4.team09.otboo.module.domain.user.repository.UserRepository;
-import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,12 +22,29 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
 
   @Mock
   private NotificationRepository notificationRepository;
+
+  @Mock
+  private NotificationRepositoryQueryDSL notificationRepositoryQueryDSL;
 
   @Mock
   private NotificationMapper notificationMapper;
@@ -157,6 +173,77 @@ class NotificationServiceTest {
       verify(notificationRepository).saveAll(any());
     }
   }
+
+  @Test
+  @DisplayName("알림 목록 조회 성공")
+  void getNotificationListSuccess() {
+    // given
+    UUID receiverId = UUID.randomUUID();
+    UUID idAfter = UUID.randomUUID();
+    int limit = 5;
+    LocalDateTime cursorTime = LocalDateTime.now().minusDays(1);
+    String cursor = cursorTime.toString();
+
+    // mock 알림 6개 (limit + 1)
+    List<Notification> fakeNotifications = IntStream.range(0, 6)
+            .mapToObj(i -> Notification.create(
+                    receiverId,
+                    "제목 " + i,
+                    "내용 " + i,
+                    Notification.Level.INFO
+            ))
+            .collect(Collectors.toList());
+
+    // id, createdAt 설정
+    for (int i = 0; i < fakeNotifications.size(); i++) {
+      Notification noti = fakeNotifications.get(i);
+      UUID id = UUID.randomUUID();
+      LocalDateTime createdAt = cursorTime.plusMinutes(i);
+      ReflectionTestUtils.setField(noti, "id", id);
+      ReflectionTestUtils.setField(noti, "createdAt", createdAt);
+    }
+
+    // DTO mock
+    List<NotificationDto> fakeDtos = fakeNotifications.stream()
+            .map(noti -> new NotificationDto(
+                    (UUID) ReflectionTestUtils.getField(noti, "id"),
+                    noti.getCreatedAt(),
+                    noti.getReceiverId(),
+                    noti.getTitle(),
+                    noti.getContent(),
+                    noti.getLevel()
+            ))
+            .collect(Collectors.toList());
+
+    // when
+    when(notificationRepositoryQueryDSL.getNotifications(eq(receiverId), any(), any(), eq(limit + 1)))
+            .thenReturn(fakeNotifications);
+    when(notificationRepositoryQueryDSL.countNotifications(eq(receiverId))).thenReturn(123);
+
+    for (int i = 0; i < fakeNotifications.size(); i++) {
+      when(notificationMapper.toDto(fakeNotifications.get(i))).thenReturn(fakeDtos.get(i));
+    }
+
+    // when
+    NotificationDtoCursorResponse result = notificationService.get(receiverId, cursor, idAfter, limit);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.data()).hasSize(limit); // limit만큼 잘린지 확인
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.totalCount()).isEqualTo(123);
+    assertThat(result.sortBy()).isEqualTo("createdAt, id");
+    assertThat(result.sortDirection()).isEqualTo(SortDirection.DESCENDING);
+
+    NotificationDto lastDto = fakeDtos.get(limit - 1);
+    assertThat(result.nextCursor()).isEqualTo(lastDto.createdAt().toString());
+    assertThat(result.nextIdAfter()).isEqualTo(lastDto.id());
+
+    // verify
+    verify(notificationRepositoryQueryDSL).getNotifications(eq(receiverId), any(), any(), eq(limit + 1));
+    verify(notificationRepositoryQueryDSL).countNotifications(eq(receiverId));
+  }
+
 
   @Nested
   @DisplayName("알림 삭제")


### PR DESCRIPTION
## Issue Number
115

## 요약(Summary)
알림 목록 조회 및 DM 목록 조회 테스트 구현

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택)
### 알림 목록 조회 테스트
- 전체 알림 목록 생성일, id 내림차순 조회
- 로그인한 사용자의 알림만 조회됨
- 커서 페이징 작동
<img width="1375" height="867" alt="image" src="https://github.com/user-attachments/assets/36755a95-7a2a-4249-9eaa-993e18beb87d" />
- totalCount 반환
<img width="1322" height="387" alt="image" src="https://github.com/user-attachments/assets/1508ba7b-b1eb-4302-a8c6-925bdc32e4f9" />

### 디엠 목록 조회 테스트
- 양방향 생성일, id 오름차순 조회
- 양쪽 로그인 후 같은 내용 모두 조회됨
- 커서 페이징 작동

[테스트모음.zip](https://github.com/user-attachments/files/21421957/default.zip)

## 공유사항 to 리뷰어
- 알림 목록 조회 구현 및 테스트와 DM 목록 조회 테스트 함께 PR 합니다.

## Close Issue

close #115